### PR TITLE
check if stdout is empty before continuing on error

### DIFF
--- a/kit/exercise/command_line.go
+++ b/kit/exercise/command_line.go
@@ -41,8 +41,14 @@ func CommandLine(t *testing.T, sc *score.Score, answers Commands) {
 		err := cmd.Run()
 		if err != nil {
 			t.Errorf("%v\n%v: %v.\n", sc.TestName, err, serr.String())
-			sc.Dec()
-			continue
+
+			// If length of stdout > 0, then the application probably puts its error output in stdout
+			// instead of stderr. In that case we want to check the contents of stdout in the switch
+			// statement below to determine whether to decrement the score.
+			if sout.Len() == 0 {
+				sc.Dec()
+				continue
+			}
 		}
 
 		outStr := sout.String()


### PR DESCRIPTION
Some applications (e.g. golangci-lint) send the output to stdout
rather than stderr on an "error". In such cases it's desirable to
compare the error output with the expected output.

This fix uses the contents of stdout to determine if the test failed
in the case stdout has any content.