### PR TITLE
Return stdout, stderr, error from func CommandLine

### DIFF
--- a/kit/exercise/command_line.go
+++ b/kit/exercise/command_line.go
@@ -28,9 +28,18 @@ type Commands []struct {
 // that students provided. The function requires the list of commands
 // and their expected answers, and a Score object. The function
 // will produce both string output and JSON output.
-func CommandLine(t *testing.T, sc *score.Score, answers Commands) {
+//
+// In addition to displaying error output through the t argument, the
+// output written to stdout and stderr, along with the error message
+// of each command, are returned in the respective stdout, stderr and
+// errors slices, where indices match those of the commands.
+func CommandLine(t *testing.T, sc *score.Score, answers Commands) (stdout []string, stderr []string, errors []error) {
 	defer sc.WriteString(os.Stdout)
 	defer sc.WriteJSON(os.Stdout)
+
+	stdout = make([]string, len(answers))
+	stderr = make([]string, len(answers))
+	errors = make([]error, len(answers))
 
 	for i := range answers {
 		cmdArgs := strings.Split(answers[i].Command, " ")
@@ -39,6 +48,10 @@ func CommandLine(t *testing.T, sc *score.Score, answers Commands) {
 		var sout, serr bytes.Buffer
 		cmd.Stdout, cmd.Stderr = &sout, &serr
 		err := cmd.Run()
+		// Store the outputs and error to be returned
+		stdout[i] = sout.String()
+		stderr[i] = serr.String()
+		errors[i] = err
 		if err != nil {
 			t.Errorf("%v\n%v: %v.\n", sc.TestName, err, serr.String())
 
@@ -74,4 +87,6 @@ func CommandLine(t *testing.T, sc *score.Score, answers Commands) {
 			}
 		}
 	}
+
+	return
 }

--- a/kit/exercise/command_line.go
+++ b/kit/exercise/command_line.go
@@ -40,7 +40,10 @@ func (e CommandLineError) StdErr() string {
 	return e.stdErr
 }
 
-func (e CommandLineError) Error() string {
+func (e *CommandLineError) Error() string {
+	if e == nil || e.err == nil {
+		return ""
+	}
 	return e.err.Error()
 }
 

--- a/kit/exercise/command_line.go
+++ b/kit/exercise/command_line.go
@@ -24,6 +24,26 @@ type Commands []struct {
 	Search  SearchType
 }
 
+// CommandLineError contains the stdout, stderr and error from a command line
+// execution returned by the CommandLine function.
+type CommandLineError struct {
+	stdOut string
+	stdErr string
+	err    error
+}
+
+func (e CommandLineError) StdOut() string {
+	return e.stdOut
+}
+
+func (e CommandLineError) StdErr() string {
+	return e.stdErr
+}
+
+func (e CommandLineError) Error() string {
+	return e.err.Error()
+}
+
 // CommandLine computes the score for a set of command line exercises
 // that students provided. The function requires the list of commands
 // and their expected answers, and a Score object. The function
@@ -31,40 +51,37 @@ type Commands []struct {
 //
 // In addition to displaying error output through the t argument, the
 // output written to stdout and stderr, along with the error message
-// of each command, are returned in the respective stdout, stderr and
-// errors slices, where indices match those of the commands.
-func CommandLine(t *testing.T, sc *score.Score, answers Commands) (stdout []string, stderr []string, errors []error) {
+// of each command, are returned in the CommandLineError slice,
+// where indices match those of the commands.
+func CommandLine(t *testing.T, sc *score.Score, answers Commands) []CommandLineError {
 	defer sc.WriteString(os.Stdout)
 	defer sc.WriteJSON(os.Stdout)
 
-	stdout = make([]string, len(answers))
-	stderr = make([]string, len(answers))
-	errors = make([]error, len(answers))
-
+	cmdLineErrors := make([]CommandLineError, len(answers))
 	for i := range answers {
 		cmdArgs := strings.Split(answers[i].Command, " ")
 		cmd := exec.Command(cmdArgs[0])
 		cmd.Args = cmdArgs
-		var sout, serr bytes.Buffer
-		cmd.Stdout, cmd.Stderr = &sout, &serr
+		var stdOut, stdErr bytes.Buffer
+		cmd.Stdout, cmd.Stderr = &stdOut, &stdErr
 		err := cmd.Run()
 		// Store the outputs and error to be returned
-		stdout[i] = sout.String()
-		stderr[i] = serr.String()
-		errors[i] = err
+		cmdLineErrors[i].stdOut = stdOut.String()
+		cmdLineErrors[i].stdErr = stdErr.String()
+		cmdLineErrors[i].err = err
 		if err != nil {
-			t.Errorf("%v\n%v: %v.\n", sc.TestName, err, serr.String())
+			t.Errorf("%v\n%v: %v.\n", sc.TestName, err, stdErr.String())
 
 			// If length of stdout > 0, then the application probably puts its error output in stdout
 			// instead of stderr. In that case we want to check the contents of stdout in the switch
 			// statement below to determine whether to decrement the score.
-			if sout.Len() == 0 {
+			if stdOut.Len() == 0 {
 				sc.Dec()
 				continue
 			}
 		}
 
-		outStr := sout.String()
+		outStr := stdOut.String()
 		// Compare output with expected output
 		switch answers[i].Search {
 		case ResultEquals:
@@ -88,5 +105,5 @@ func CommandLine(t *testing.T, sc *score.Score, answers Commands) (stdout []stri
 		}
 	}
 
-	return
+	return cmdLineErrors
 }

--- a/kit/exercise/command_line_test.go
+++ b/kit/exercise/command_line_test.go
@@ -1,0 +1,31 @@
+package exercise
+
+import (
+	"testing"
+
+	"github.com/autograde/quickfeed/kit/score"
+)
+
+func TestCmdLine(t *testing.T) {
+	// TODO(meling) the following works, but doesn't exercise the test failure
+	// cmds := Commands{
+	// 	{Command: "ls -l", Result: "command_line.go", Search: ResultContains},
+	// 	{Command: "ls -a", Result: "command_line.go", Search: ResultContains},
+	// }
+	// The following is expected to fail:
+	cmds := Commands{
+		{Command: "ls -l", Result: "command_line.go", Search: ResultDoesNotContain},
+		{Command: "ls -a", Result: "command_line.go", Search: ResultDoesNotContain},
+		{Command: "obviouslyDoesntWork", Result: "works", Search: ResultEquals},
+	}
+	sc := score.NewScoreMax(10, 1)
+	outs := CommandLine(t, sc, cmds)
+	for i := 0; i < len(cmds); i++ {
+		t.Logf("stdout: %s", outs[i].StdOut())
+		t.Logf("stderr: %s", outs[i].StdErr())
+		if outs[i].err == nil {
+			t.Logf("STEP %d: ERROR IS NIL", i)
+		}
+		t.Logf("err: %v", outs[i].Error())
+	}
+}


### PR DESCRIPTION
Motivation: The output from the CommandLine function is minimal in
some cases. E.g. in our use-case we wanted to detect a data race by
running `go test -race ...` with the CommandLine function and looking
for "DATA RACE" in the output. However we were unable to show the full
output (stack trace etc.) related to the data race when it was found.

With this update the output to stdout and stderr along with any error
from exec.Command are returned as slices, one for each command that
is run. As a result, callers of CommandLine can investigate the
results and use them as they please when some error occurs. Since
there were no return values before, this change should not conflict
with existing code.

I was not sure about introducing new types, but you might also
consider a "CommandLineError" type similar to the following:

```go
type CommandLineError struct {
  // output to stdout
  Stdout string
  // output to stderr
  Stderr string
  // error from executing the command with the exec package
  Err error
}

func (e CommandLineError) Error() string {
  return e.Err.Error()
}
```

Then CommandLine could return `[]CommandLineError` instead.