### PR TITLE
Reducing noise in the server logs

### DIFF
--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -114,7 +114,6 @@ func jsonString(event interface{}) string {
 func (wh GitHubWebHook) extractAssignments(payload *github.PushEvent, course *pb.Course) []*pb.Assignment {
 	modifiedAssignments := make(map[string]bool)
 	for _, commit := range payload.Commits {
-		wh.logger.Debugf("Examining commit (%s) for modifications/additions/removals", commit.GetID())
 		extractChanges(commit.Modified, modifiedAssignments)
 		extractChanges(commit.Added, modifiedAssignments)
 		extractChanges(commit.Removed, modifiedAssignments)


### PR DESCRIPTION
Removed a line that made logger print out every commit made by the student to their lab repository on every new push to that repository.