### PR TITLE
Order lab submissions by assignment's order

### DIFF
--- a/database/gormdb_assignment.go
+++ b/database/gormdb_assignment.go
@@ -96,7 +96,7 @@ func (db *GormDB) UpdateAssignments(assignments []*pb.Assignment) error {
 func (db *GormDB) GetCourseAssignmentsWithSubmissions(courseID uint64, submissionType pb.SubmissionsForCourseRequest_Type) ([]*pb.Assignment, error) {
 	var assignments []*pb.Assignment
 
-	if err := db.conn.Preload("Submissions").Preload("Submissions.Reviews").Where(&pb.Assignment{CourseID: courseID}).Find(&assignments).Error; err != nil {
+	if err := db.conn.Preload("Submissions").Preload("Submissions.Reviews").Where(&pb.Assignment{CourseID: courseID}).Order("order").Find(&assignments).Error; err != nil {
 		fmt.Println(err.Error())
 		return nil, err
 	}

--- a/public/src/managers/CourseManager.ts
+++ b/public/src/managers/CourseManager.ts
@@ -352,6 +352,7 @@ export class CourseManager {
         if (!assignments) {
             assignments = await this.getAssignments(course.getId());
         }
+        assignments = sortAssignmentsByOrder(assignments);
         for (const studentLabs of labLinks) {
             studentLabs.course = course;
 

--- a/public/src/pages/TeacherPage.tsx
+++ b/public/src/pages/TeacherPage.tsx
@@ -146,7 +146,6 @@ export class TeacherPage extends ViewPage {
             const results = await this.courseMan.getLabsForCourse(course.getId(), SubmissionsForCourseRequest.Type.GROUP);
             const labs = await this.courseMan.getAssignments(course.getId());
             const labResults = await this.courseMan.fillLabLinks(course, results, labs);
-            const curUser = this.userMan.getCurrentUser();
             return <GroupResults
                 course={course}
                 courseURL={await this.getCourseURL(course.getId())}


### PR DESCRIPTION
Fixes the issue where `Results` table had assignments in the table header sorted by the Assignment's field `Order`, while submissions in the table body were sorted by the Assignment's database ID, which could cause a bug where submissions in the table column were displayed for a wrong assignment.