### PR TITLE
emit 0 score JSON at start and updated with a non-zero score JSON

### DIFF
--- a/ci/results_test.go
+++ b/ci/results_test.go
@@ -44,6 +44,66 @@ Here are some more logs for the student.
 	}
 }
 
+func TestExtractResultWithTwoScoreLines(t *testing.T) {
+	out := `here is some output in the log with whitespace before the JSON string below.
+
+    {"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"Gradle","Score":0,"MaxScore":100,"Weight":1}
+
+Here are some more logs for the student.
+    {"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"Gradle","Score":100,"MaxScore":100,"Weight":1}
+
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"JoGo","Score":0,"MaxScore":100,"Weight":1}
+
+Here are some more logs for the student.
+`
+
+	res, err := ExtractResult(zap.NewNop().Sugar(), out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Scores) != 2 {
+		t.Fatalf("ExtractResult() expected 2 Score entries, got %d: %+v", len(res.Scores), res.Scores)
+	}
+}
+
+func TestExtractResultWithPanicedAndMaliciousScoreLines(t *testing.T) {
+	out := `
+    {"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"GoodTest1","Score":0,"MaxScore":100,"Weight":1}
+    {"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"GoodTest1","Score":100,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"GoodTest2","Score":0,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"GoodTest2","Score":50,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"PanicedTest1","Score":0,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"PanicedTest2","Score":0,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"PanicedTest3","Score":0,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"MaliciousTest","Score":100,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"MaliciousTest","Score":100,"MaxScore":100,"Weight":1}
+	{"Secret":"59fd5fe1c4f741604c1beeab875b9c789d2a7c73","TestName":"MaliciousTest","Score":100,"MaxScore":100,"Weight":1}
+`
+
+	res, err := ExtractResult(zap.NewNop().Sugar(), out, "59fd5fe1c4f741604c1beeab875b9c789d2a7c73", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const expected = 6
+	if len(res.Scores) != expected {
+		t.Fatalf("ExtractResult() expected %d Score entries, got %d: %+v", expected, len(res.Scores), res.Scores)
+	}
+
+	testOrder := []string{
+		"GoodTest1",
+		"GoodTest2",
+		"PanicedTest1",
+		"PanicedTest2",
+		"PanicedTest3",
+		"MaliciousTest",
+	}
+	for i, score := range res.Scores {
+		if score.TestName != testOrder[i] {
+			t.Errorf("ExtractResult() returned unexpected order of tests: expected %s, got %s", testOrder[i], score.TestName)
+		}
+	}
+}
+
 func TestExecTime(t *testing.T) {
 	tests := []struct {
 		id   string

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.4.2
-	github.com/google/go-cmp v0.5.1
+	github.com/google/go-cmp v0.5.2
 	github.com/google/go-github/v30 v30.1.0
 	github.com/gorilla/mux v1.7.4 // indirect
 	github.com/gorilla/sessions v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github/v27 v27.0.4/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
 github.com/google/go-github/v30 v30.1.0 h1:VLDx+UolQICEOKu2m4uAoMti1SxuEBAl7RSEG16L+Oo=
 github.com/google/go-github/v30 v30.1.0/go.mod h1:n8jBpHl45a/rlBUtRJMOG4GhNADUQFEufcolZ95JfU8=

--- a/kit/.vscode/settings.json
+++ b/kit/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "atoi",
+        "cmds",
         "malloc",
         "printf",
         "struct"

--- a/kit/exercise/command_line_test.go
+++ b/kit/exercise/command_line_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestCmdLine(t *testing.T) {
+	t.Skip("This is expected to fail, so we skip it when running normally (see comment).")
+
 	// TODO(meling) the following works, but doesn't exercise the test failure
 	// cmds := Commands{
 	// 	{Command: "ls -l", Result: "command_line.go", Search: ResultContains},
@@ -16,9 +18,9 @@ func TestCmdLine(t *testing.T) {
 	cmds := Commands{
 		{Command: "ls -l", Result: "command_line.go", Search: ResultDoesNotContain},
 		{Command: "ls -a", Result: "command_line.go", Search: ResultDoesNotContain},
-		{Command: "obviouslyDoesntWork", Result: "works", Search: ResultEquals},
+		{Command: "obviouslyDoesNotWork", Result: "works", Search: ResultEquals},
 	}
-	sc := score.NewScoreMax(10, 1)
+	sc := score.NewScoreMax(t, 10, 1)
 	outs := CommandLine(t, sc, cmds)
 	for i := 0; i < len(cmds); i++ {
 		t.Logf("stdout: %s", outs[i].StdOut())

--- a/kit/exercise/multiple_choice.go
+++ b/kit/exercise/multiple_choice.go
@@ -42,7 +42,7 @@ func parseMCAnswers(mdFile string) (map[string]string, error) {
 
 func MultipleChoiceWithDesc(t *testing.T, mdFile string, correct map[int]string) {
 	t.Helper()
-	sc := score.NewScoreMaxWithTesting(t, len(correct), 1)
+	sc := score.NewScoreMax(t, len(correct), 1)
 	defer sc.WriteString(os.Stdout)
 	defer sc.WriteJSON(os.Stdout)
 

--- a/kit/exercise/multiple_choice_test.go
+++ b/kit/exercise/multiple_choice_test.go
@@ -31,7 +31,7 @@ func TestMultipleChoice(t *testing.T) {
 	// as a table-driven test.
 
 	oldStyleMC := filepath.Join("..", "testdata", "old-style-answers.md")
-	sc := score.NewScoreMax(len(answers), 1)
+	sc := score.NewScoreMax(t, len(answers), 1)
 	exercise.MultipleChoice(t, sc, oldStyleMC, answers)
 }
 

--- a/kit/go.mod
+++ b/kit/go.mod
@@ -2,4 +2,4 @@ module github.com/autograde/quickfeed/kit
 
 go 1.14
 
-require github.com/google/go-cmp v0.5.1
+require github.com/google/go-cmp v0.5.2

--- a/kit/go.sum
+++ b/kit/go.sum
@@ -1,3 +1,4 @@
-github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
-github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/kit/score/score_test.go
+++ b/kit/score/score_test.go
@@ -41,7 +41,7 @@ var fibonacciTests = []struct {
 }
 
 func TestFibonacci(t *testing.T) {
-	sc := NewScoreMax(len(fibonacciTests)*2, 20)
+	sc := NewScoreMax(t, len(fibonacciTests)*2, 20)
 	defer sc.WriteJSON(os.Stdout)
 
 	for _, ft := range fibonacciTests {
@@ -59,7 +59,7 @@ func TestFibonacci(t *testing.T) {
 }
 
 var nonJSONLog = []string{
-	"heere is some output",
+	"here is some output",
 	"some other output",
 	"line contains " + theSecret,
 	theSecret + " should not be revealed",
@@ -78,16 +78,16 @@ func TestParseNonJSONStrings(t *testing.T) {
 }
 
 var jsonLog = []struct {
-	in  string
-	out *Score
-	err error
+	in          string
+	max, weight int
+	err         error
 }{
-	{`{"Secret":"` + theSecret + `","TestName":"init","Score":0,"MaxScore":10,"Weight":10}`,
-		NewScore(10, 10),
+	{`{"Secret":"` + theSecret + `","TestName":"TestParseJSONStrings","Score":0,"MaxScore":10,"Weight":10}`,
+		10, 10,
 		nil,
 	},
-	{`{"Secret":"the wrong secret","TestName":"init","Score":0,"MaxScore":10,"Weight":10}`,
-		nil,
+	{`{"Secret":"the wrong secret","TestName":"TestParseJSONStrings","Score":0,"MaxScore":10,"Weight":10}`,
+		-1, -1,
 		ErrScoreNotFound,
 	},
 }
@@ -104,10 +104,14 @@ func (sc *Score) Equal(other *Score) bool {
 func TestParseJSONStrings(t *testing.T) {
 	for _, s := range jsonLog {
 		sc, err := Parse(s.in, GlobalSecret)
-		if sc != s.out || err != s.err {
-			if !s.out.Equal(sc) || err != s.err {
+		var expectedScore *Score
+		if s.max > 0 {
+			expectedScore = NewScore(t, s.max, s.weight)
+		}
+		if sc != expectedScore || err != s.err {
+			if !expectedScore.Equal(sc) || err != s.err {
 				t.Errorf("Failed to parse:\n%v\nGot: '%v', '%v'\nExp: '%v', '%v'",
-					s.in, sc, err, s.out, s.err)
+					s.in, sc, err, expectedScore, s.err)
 			}
 			if sc != nil && sc.Secret == GlobalSecret {
 				t.Errorf("Parse function failed to hide global secret: %v", sc.Secret)

--- a/kit/score/totalscore_test.go
+++ b/kit/score/totalscore_test.go
@@ -2,27 +2,35 @@ package score
 
 import "testing"
 
-var scores = []struct {
-	in  []*Score
-	out uint32
-}{
-	{[]*Score{setScore(10, 10, 1), setScore(5, 5, 1), setScore(15, 15, 1)}, 100},
-	{[]*Score{setScore(5, 10, 1), setScore(5, 5, 1), setScore(20, 40, 1)}, 66},
-	{[]*Score{setScore(5, 10, 1), setScore(5, 10, 1), setScore(20, 40, 1)}, 50},
-	{[]*Score{setScore(10, 10, 2), setScore(5, 10, 1), setScore(20, 40, 1)}, 75},
-	{[]*Score{setScore(0, 10, 2), setScore(0, 10, 1), setScore(0, 40, 1)}, 0},
-	{[]*Score{}, 0},
+type scoreData struct {
+	points, max, weight int
 }
 
-func setScore(points, max, w int) *Score {
-	s := NewScore(max, w)
-	s.IncBy(points)
-	return s
+var scores = []struct {
+	in  []*scoreData
+	out uint32
+}{
+	{[]*scoreData{setScore(10, 10, 1), setScore(5, 5, 1), setScore(15, 15, 1)}, 100},
+	{[]*scoreData{setScore(5, 10, 1), setScore(5, 5, 1), setScore(20, 40, 1)}, 66},
+	{[]*scoreData{setScore(5, 10, 1), setScore(5, 10, 1), setScore(20, 40, 1)}, 50},
+	{[]*scoreData{setScore(10, 10, 2), setScore(5, 10, 1), setScore(20, 40, 1)}, 75},
+	{[]*scoreData{setScore(0, 10, 2), setScore(0, 10, 1), setScore(0, 40, 1)}, 0},
+	{[]*scoreData{}, 0},
+}
+
+func setScore(points, max, w int) *scoreData {
+	return &scoreData{points: points, max: max, weight: w}
 }
 
 func TestTotal(t *testing.T) {
 	for _, s := range scores {
-		tot := Total(s.in)
+		allScores := make([]*Score, 0)
+		for _, sd := range s.in {
+			sc := NewScore(t, sd.max, sd.weight)
+			sc.IncBy(sd.points)
+			allScores = append(allScores, sc)
+		}
+		tot := Total(allScores)
 		if tot != s.out {
 			t.Errorf("Got: %d, Want: %d", tot, s.out)
 		}


### PR DESCRIPTION
This commit fixes #315.

This commit updates the score package in kit module to always
write an initial Score JSON to StdOut. This prevents test score
values from getting lost when students do something wrong which
causes the test execution to panic.

This change implies that Quickfeed must filter the Score JSON
strings found in the results log so that only one Score is
returned and used in the calculation of the Total.
When filtering, we assume only one or two Score strings;
if only one is found, it means that it is the one initialized
by the NewScore* constructor, and it is used, giving only 0 score;
if two is found, only the last one is used, meaning that the
score is the result of running some tests;
if more than two are found, something is amiss and we return
a 0 score object.

This commit also updates the API of NewScore and NewScoreMax.
These functions now take the *testing.T as the first argument,
which is only used to get the test's Name(), which is much more
reliable than our previous approach.

This also removes NewScoreMaxWithTesting() which did the same
and the old testName() helper function, which was unreliable.

Note: This change may not resolve the issue caused by test timeouts,
e.g. due to infinite loops, where there are remaining tests that didn't
get started. Similarly, if a test panics that prevents remaining ones
from even starting, this change will not fix this.