### PR TITLE
another attempt at fixing the too many open file descriptors issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,8 @@
         "path": "/usr/local/bin/protoc",
         "options": [
             "--proto_path=${workspaceRoot}/ag",
-            "--proto_path=${env.HOME}/go/pkg/mod/github.com/gogo/protobuf@v1.3.1",
-        ],
+            "--proto_path=${env.HOME}/go/pkg/mod/github.com/gogo/protobuf@v1.3.1"
+        ]
     },
     "go.lintTool": "golangci-lint",
     "go.lintFlags": [
@@ -14,6 +14,7 @@
         "Autograder",
         "Debugf",
         "Gorm",
+        "LOGDB",
         "Repos",
         "agpath",
         "assignmentid",
@@ -28,6 +29,7 @@
         "goveralls",
         "grpc",
         "jinzhu",
+        "lsof",
         "mattn",
         "opsys",
         "quickfeed",

--- a/ci/docker_test.go
+++ b/ci/docker_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -42,7 +43,12 @@ func TestDocker(t *testing.T) {
 		wantOut = "hello world"
 	)
 
-	docker := &ci.Docker{}
+	docker, err := ci.NewDockerCI()
+	if err != nil {
+		t.Fatalf("failed to set up docker client: %v", err)
+	}
+	defer docker.Close()
+
 	out, err := docker.Run(context.Background(), &ci.Job{
 		Name:     "TestDocker-" + randomString(t),
 		Image:    "golang:latest",
@@ -73,7 +79,12 @@ func TestDockerTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	defer cancel()
 
-	docker := &ci.Docker{}
+	docker, err := ci.NewDockerCI()
+	if err != nil {
+		t.Fatalf("failed to set up docker client: %v", err)
+	}
+	defer docker.Close()
+
 	out, err := docker.Run(ctx, &ci.Job{
 		Name:     "TestDockerTimeout-" + randomString(t),
 		Image:    "golang:latest",
@@ -88,6 +99,66 @@ func TestDockerTimeout(t *testing.T) {
 	if err == nil {
 		t.Errorf("docker.Run(%#v) unexpectedly returned without error", script)
 	}
+}
+
+func TestDockerOpenFileDescriptors(t *testing.T) {
+	// This is mainly for debugging the 'too many open file descriptors' issue
+	if !docker {
+		t.SkipNow()
+	}
+
+	const (
+		script        = `echo -n "hello, " && sleep 2 && echo -n "world!"`
+		wantOut       = "hello, world!"
+		numContainers = 5
+	)
+
+	docker, err := ci.NewDockerCI()
+	if err != nil {
+		t.Fatalf("failed to set up docker client: %v", err)
+	}
+	defer docker.Close()
+
+	errCh := make(chan error, numContainers)
+	for i := 0; i < numContainers; i++ {
+		go func(j int) {
+			name := fmt.Sprintf("TestDockerOpenFileDescritors-%d-%s", j, randomString(t))
+			out, err := docker.Run(context.Background(), &ci.Job{
+				Name:     name,
+				Image:    "golang:latest",
+				Commands: []string{script},
+			})
+			if err != nil {
+				errCh <- err
+			}
+			if out != wantOut {
+				t.Errorf("docker.Run(%#v) = %#v, want %#v", script, out, wantOut)
+			}
+			errCh <- nil
+		}(i)
+	}
+	afterContainersStarted := countOpenFiles(t)
+
+	for i := 0; i < numContainers; i++ {
+		err := <-errCh
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(errCh)
+	afterContainersFinished := countOpenFiles(t)
+	if afterContainersFinished > afterContainersStarted {
+		t.Errorf("finished %d > started %d", afterContainersFinished, afterContainersStarted)
+	}
+}
+
+func countOpenFiles(t *testing.T) int {
+	t.Helper()
+	out, err := exec.Command("/bin/sh", "-c", fmt.Sprintf("lsof -p %v", os.Getpid())).Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return bytes.Count(out, []byte("\n"))
 }
 
 func randomString(t *testing.T) string {

--- a/main.go
+++ b/main.go
@@ -115,7 +115,13 @@ func main() {
 		Secret:  os.Getenv("WEBHOOK_SECRET"),
 	}
 
-	agService := web.NewAutograderService(logger, db, scms, bh, &ci.Docker{})
+	runner, err := ci.NewDockerCI()
+	if err != nil {
+		log.Fatalf("failed to set up docker client: %v\n", err)
+	}
+	defer runner.Close()
+
+	agService := web.NewAutograderService(logger, db, scms, bh, runner)
 	go web.New(agService, *public, *httpAddr, *scriptPath, *fake)
 
 	lis, err := net.Listen("tcp", *grpcAddr)


### PR DESCRIPTION
This commit fixes #319 (for real this time).
Now we create only one docker client when we start quickfeed,
instead of creating a separate docker client instance for each
job we want to run. This should hopefully save even more resources
and maybe some execution time for tests.

If this does not work correctly for some reason, we can revert to
the previous version, and instead make sure we close the client
between each job run. But that seems wasteful, and hence I wanted
to reuse the client across jobs. The way I understand the client,
it can still create, stop, get logs from and remove several
containers; that is, we shouldn't need a separate client for doing
these tasks.
