### PR TITLE
Fix issue with docker image names with slashes

### DIFF
--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -54,7 +54,7 @@ func parseScriptTemplate(scriptPath string, info *AssignmentInfo) (*Job, error) 
 	if len(s) < 2 {
 		return nil, fmt.Errorf("no script template in %s", tmplFile)
 	}
-	parts := strings.Split(s[0], "/")
+	parts := strings.SplitN(s[0], "/", 1)
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("no docker image specified in script template %s", tmplFile)
 	}

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -54,7 +54,7 @@ func parseScriptTemplate(scriptPath string, info *AssignmentInfo) (*Job, error) 
 	if len(s) < 2 {
 		return nil, fmt.Errorf("no script template in %s", tmplFile)
 	}
-	parts := strings.SplitN(s[0], "/", 1)
+	parts := strings.Split(s[0], "#image/")
 	if len(parts) < 2 {
 		return nil, fmt.Errorf("no docker image specified in script template %s", tmplFile)
 	}

--- a/ci/parse_script_test.go
+++ b/ci/parse_script_test.go
@@ -32,6 +32,9 @@ func TestParseScript(t *testing.T) {
 			fmt.Println(cmd)
 		}
 	}
+	if os.Getenv("TEST_IMAGE") != "" {
+		fmt.Println(j.Image)
+	}
 
 	info.Script = "python361.sh"
 	_, err = parseScriptTemplate("scripts", info)
@@ -43,5 +46,19 @@ func TestParseScript(t *testing.T) {
 	_, err = parseScriptTemplate("scripts", info)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	info.Script = "python-dat550.sh"
+	j, err = parseScriptTemplate("scripts", info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.Getenv("TEST_TMPL") != "" {
+		for _, cmd := range j.Commands {
+			fmt.Println(cmd)
+		}
+	}
+	if os.Getenv("TEST_IMAGE") != "" {
+		fmt.Println(j.Image)
 	}
 }

--- a/ci/scripts/python-dat550.sh
+++ b/ci/scripts/python-dat550.sh
@@ -1,0 +1,30 @@
+#image/docker.io/eiriksak/school:dat550
+
+echo "\n\n==Start_CI==\n"
+git config --global url."https://{{ .CreatorAccessToken }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
+
+cd /root/
+export PYTHONPATH="/root"
+
+git clone {{ .GetURL }} user
+git clone {{ .TestURL }} test
+
+history -c
+
+
+if [ -f "test/{{ .AssignmentName }}/setup.sh" ]; then
+    cd test/{{ .AssignmentName }}/
+    bash setup.sh
+    cd /root/
+fi
+
+
+# Secret is dumpted to a file and must be read by the scoring module
+
+cat <<EOF > /root/test/secret.txt
+{{ .RandomSecret }}
+EOF
+
+# Standard naming convention - must be ag_run.py in every lab
+python test/{{ .AssignmentName }}/ag_run.py 2>&1
+echo "\n==DONE_CI==\n"


### PR DESCRIPTION
This commit fixes an issue with docker image names listed
on the first line starting with #image/ where the image
name following after the inital / also contains slashes,
e.g. docker.io/eiriksak/school:dat550

