### PR TITLE
UpdateSlipdays with a graceperiod

### DIFF
--- a/ag/enrollment.go
+++ b/ag/enrollment.go
@@ -5,8 +5,9 @@ import (
 	"time"
 )
 
-// gracePeriod is the grace period for submissions after the deadline. It should be <int> hours, in the range 0-23.
-// Note grace period applies to all enrollments (courses)
+// gracePeriod is the grace period for submissions after the deadline.
+// The grace period should be hours in the range 0-23.
+// Note grace period applies to all enrollments (courses).
 const gracePeriod time.Duration = time.Duration(2 * time.Hour)
 
 // UpdateSlipDays updates the number of slipdays for the given assignment/submission.
@@ -25,7 +26,7 @@ func (m *Enrollment) UpdateSlipDays(start time.Time, assignment *Assignment, sub
 	if submission.Score < assignment.ScoreLimit && submission.Status != Submission_APPROVED && sinceDeadline > 0 {
 		// deadline exceeded; calculate used slipdays for this assignment
 		slpDays, slpHours := uint32(sinceDeadline/days), sinceDeadline%days
-		//slpHours is time after deadline. This is also correct on subsequent slipdays after deadline has passed
+		// slpHours is hours after deadline, excluding subsequent full-day slipdays after deadline
 		if slpHours > gracePeriod {
 			slpDays++
 		}

--- a/ag/enrollment.go
+++ b/ag/enrollment.go
@@ -5,11 +5,9 @@ import (
 	"time"
 )
 
-//gracePeriod is the grace-Period for deliveries after the deadline. It can only be <int> hours.
-//Currently there is a 2 hour grace period. It should be between [0,1,..,23]
+// gracePeriod is the grace period for submissions after the deadline. It should be <int> hours, in the range 0-23.
+// Note grace period applies to all enrollments (courses)
 const gracePeriod time.Duration = time.Duration(2 * time.Hour)
-
-//Keep in mind this will be the same across all enrollments (courses) on the AG service.
 
 // UpdateSlipDays updates the number of slipdays for the given assignment/submission.
 func (m *Enrollment) UpdateSlipDays(start time.Time, assignment *Assignment, submission *Submission) error {
@@ -31,7 +29,6 @@ func (m *Enrollment) UpdateSlipDays(start time.Time, assignment *Assignment, sub
 		if slpHours > gracePeriod {
 			slpDays++
 		}
-		//updating the slipdays
 		m.updateSlipDays(assignment.GetID(), slpDays)
 	}
 	return nil


### PR DESCRIPTION
Proposed implementation of UpdateSlipdays() including a graceperiod. 
The grace period is currently set to 2 hours. can and should be an int between [0,1,...,23].

This change can affect all assignments, that are not yet approved, on the currently running autograder service.

Currently doesn't support 1,5 hours grace-periods, using minutes instead grants this functionality.
`const gracePeriod time.Duration = time.Duration(90 * time.Minutes)`

