### PR TITLE
Fix for submissions without automated tests

### DIFF
--- a/database/gormdb_assignment.go
+++ b/database/gormdb_assignment.go
@@ -41,6 +41,7 @@ func (db *GormDB) CreateAssignment(assignment *pb.Assignment) error {
 			"is_group_lab":      assignment.IsGroupLab,
 			"reviewers":         assignment.Reviewers,
 			"container_timeout": assignment.ContainerTimeout,
+			"skip_tests":        assignment.SkipTests,
 		}).FirstOrCreate(assignment).Error
 }
 

--- a/public/src/pages/views/LabResultView.tsx
+++ b/public/src/pages/views/LabResultView.tsx
@@ -21,6 +21,12 @@ export class LabResultView extends React.Component<ILabInfoProps> {
             const latest = this.props.submissionLink.submission;
             const buildLog = latest.buildLog.split("\n").map((x, i) => <span key={i} >{x}<br /></span>);
             const score = this.props.submissionLink.assignment.getSkiptests() ? scoreFromReviews(latest.reviews) : latest.score;
+            const lastBuilTable = (<LastBuild
+            test_cases={latest.testCases}
+            score={score}
+            scoreLimit={this.props.submissionLink.assignment.getScorelimit()}
+            weight={100}
+        />)
             return (
                 <div key="labhead" className="col-md-9 col-sm-9 col-xs-12">
                     <div key="labview" className="result-content" id="resultview">
@@ -43,12 +49,7 @@ export class LabResultView extends React.Component<ILabInfoProps> {
                                 assignment={this.props.submissionLink.assignment}
                                 teacherView={this.props.teacherPageView}
                             />
-                            <LastBuild
-                                test_cases={latest.testCases}
-                                score={score}
-                                scoreLimit={this.props.submissionLink.assignment.getScorelimit()}
-                                weight={100}
-                            />
+                            {this.props.submissionLink.assignment.getSkiptests() ? null : lastBuilTable}
                             {this.props.submissionLink.assignment.getReviewers() > 0 && latest.released ? this.renderReviewInfo(latest) : null}
                             <Row><div key="loghead" className="col-lg-12"><div key="logview" className="well"><code id="logs">{buildLog}</code></div></div></Row>
                         </section>

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -168,7 +168,7 @@ func (wh GitHubWebHook) runAssignmentTests(assignment *pb.Assignment, repo *pb.R
 		JobOwner:   payload.GetSender().GetLogin(),
 	}
 	if assignment.SkipTests {
-		wh.logger.Debugf("Assignment %s for course %s has no automated test, skipping tests", assignment.Name, course.Name)
+		wh.logger.Debugf("Assignment %s for course %s is manually reviewed", assignment.Name, course.Name)
 		wh.recordSubmissionWithoutTests(runData)
 		return
 	}
@@ -185,7 +185,8 @@ func (wh GitHubWebHook) recordSubmissionWithoutTests(data *ci.RunData) {
 		ExecTime:  1,
 	})
 	if err != nil {
-		wh.logger.Errorf("Error marshalling build info for %s of course %s for student %s", data.Course.Name, data.Assignment.Name, data.JobOwner)
+		wh.logger.Errorf("Error marshalling build info for %s of course %s for student %s: %s", data.Course.Name, data.Assignment.Name, data.JobOwner, err)
+		return
 	}
 	newSubmission := &pb.Submission{
 		AssignmentID: data.Assignment.ID,
@@ -196,9 +197,10 @@ func (wh GitHubWebHook) recordSubmissionWithoutTests(data *ci.RunData) {
 	}
 	if err := wh.db.CreateSubmission(newSubmission); err != nil {
 		wh.logger.Errorf("Failed to save submission for user ID %s for assignment ID %d: %s", data.JobOwner, data.Assignment.ID, err)
-	} else {
-		wh.logger.Debugf("Skipping tests. Saved submission for user ID %s for assignment ID %d", data.JobOwner, data.Assignment.ID)
+		return
 	}
+	wh.logger.Debugf("Saved manual review submission for user %s for assignment %d", data.JobOwner, data.Assignment.ID)
+
 }
 
 // updateLastActivityDate sets a current date as a last activity date of the student


### PR DESCRIPTION
- fixes the issue where `SkipTests` status of an assignment would not update properly in the database
- hides the table with empty test results when displaying the build results for such assignments