### PR TITLE
Using local npm dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ pbpath				:= $(shell go list -f '{{ .Dir }}' -m github.com/gogo/protobuf)
 # necessary when target is not tied to a file
 .PHONY: download install-tools install ui proto devtools grpcweb envoy-build envoy-run scm
 
-devtools: install-tools grpcweb npmtools
+devtools: install-tools grpcweb
 
 download:
 	@echo Download go.mod dependencies
@@ -32,7 +32,7 @@ install:
 
 ui:
 	@echo Running webpack
-	@cd public; npm install; webpack
+	@cd public; npm install; npm run webpack
 
 proto:
 	@echo Compiling Autograders proto definitions
@@ -45,7 +45,7 @@ proto:
 	--js_out=import_style=commonjs:../$(proto-path)/ \
 	--grpc-web_out=import_style=typescript,mode=grpcweb:../$(proto-path)/ ag.proto
 	$(sedi) '/gogo/d' $(proto-path)/ag_pb.js $(proto-path)/AgServiceClientPb.ts $(proto-path)/ag_pb.d.ts
-	@tsc $(proto-path)/AgServiceClientPb.ts
+	@cd public && npm run tsc -- proto/AgServiceClientPb.ts
 
 grpcweb:
 	@echo "Fetch and install grpcweb protoc plugin (requires sudo access)"
@@ -54,14 +54,6 @@ grpcweb:
 	@sudo mv $(tmpdir)/$(protoc-grpcweb-long) $(grpcweb-path)
 	@chmod +x $(grpcweb-path)
 	@rm -rf $(tmpdir)
-
-npmtools:
-	@echo "Install webpack and typescript compiler (requires sudo access)"
-	@npm install -g --save typescript
-	@npm install -g --force webpack
-	@npm install -g --force webpack-cli
-	@npm install -g tslint
-	@npm install -g serve
 
 # TODO(meling) this is just for macOS; we should guard against non-macOS.
 brew:

--- a/public/package.json
+++ b/public/package.json
@@ -4,7 +4,9 @@
   "description": "React Components for the Autograder Project",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "webpack": "webpack --progress",
+    "tsc": "tsc"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
This PR remove the necessity to install ui package globally and use the local installation (based on the package.json) in the makefile when building the ui.