### PR TITLE
Fixing time.Parse layout constants

### DIFF
--- a/ag/assignments.go
+++ b/ag/assignments.go
@@ -5,16 +5,15 @@ import (
 )
 
 const (
-	layout = "2006-01-02T15:04:05"
-	days   = time.Duration(24 * time.Hour)
-	zero   = time.Duration(0)
+	days = time.Duration(24 * time.Hour)
+	zero = time.Duration(0)
 )
 
 // SinceDeadline returns the duration since the deadline.
 // A positive duration means the deadline has passed, whereas
 // a negative duration means the deadline has not yet passed.
 func (m Assignment) SinceDeadline(now time.Time) (time.Duration, error) {
-	deadline, err := time.ParseInLocation(layout, m.GetDeadline(), now.Location())
+	deadline, err := time.ParseInLocation(TimeLayout, m.GetDeadline(), now.Location())
 	if err != nil {
 		// this should not happen if deadlines are parsed and recorded correctly
 		return zero, err

--- a/ag/consts.go
+++ b/ag/consts.go
@@ -1,0 +1,7 @@
+// Global constants
+
+package ag
+
+const (
+	TimeLayout = "2006-01-02T15:04:05"
+)

--- a/ag/slipdays_test.go
+++ b/ag/slipdays_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 const (
-	layout = "2006-01-02T15:04:05"
-	days   = time.Duration(24 * time.Hour)
+	days = time.Duration(24 * time.Hour)
 )
 
 var (
@@ -26,7 +25,7 @@ var (
 		return &pb.Assignment{
 			CourseID:   course.ID,
 			ScoreLimit: 60,
-			Deadline:   testNow.Add(time.Duration(daysFromNow) * days).Format(layout),
+			Deadline:   testNow.Add(time.Duration(daysFromNow) * days).Format(pb.TimeLayout),
 		}
 	}
 )
@@ -113,7 +112,7 @@ func TestSlipDays(t *testing.T) {
 					}
 					remaining := enrol.RemainingSlipDays(course)
 					if remaining != sd.remaining[i][j] {
-						t.Errorf("UpdateSlipdays(%q, %q, %q, %q) == %d, want %d", testNow.Format(layout), sd.labs[i], submission, enrol, remaining, sd.remaining[i][j])
+						t.Errorf("UpdateSlipdays(%q, %q, %q, %q) == %d, want %d", testNow.Format(pb.TimeLayout), sd.labs[i], submission, enrol, remaining, sd.remaining[i][j])
 					}
 				}
 			})
@@ -193,7 +192,7 @@ func TestScoreLimitSlipDays(t *testing.T) {
 			}
 			remaining := enrol.RemainingSlipDays(course)
 			if uint32(remaining) != test.remaining {
-				t.Errorf("UpdateSlipdays(%q, %q, %q, %q) = %d, want %d", testNow.Format(layout), test.assignment, test.submission, enrol, remaining, test.remaining)
+				t.Errorf("UpdateSlipdays(%q, %q, %q, %q) = %d, want %d", testNow.Format(pb.TimeLayout), test.assignment, test.submission, enrol, remaining, test.remaining)
 			}
 		})
 	}
@@ -227,7 +226,7 @@ func TestMismatchingAssignmentID(t *testing.T) {
 	// lab1's deadline is incorrectly formatted
 	lab1 := &pb.Assignment{
 		CourseID: course.ID,
-		Deadline: testNow.Add(time.Duration(2) * days).Format(layout),
+		Deadline: testNow.Add(time.Duration(2) * days).Format(pb.TimeLayout),
 	}
 	lab1.ID = 1
 	submission := &pb.Submission{Status: pb.Submission_NONE, AssignmentID: lab1.ID + 1}
@@ -246,7 +245,7 @@ func TestMismatchingCourseID(t *testing.T) {
 	// lab1's deadline is incorrectly formatted
 	lab1 := &pb.Assignment{
 		CourseID: course.ID + 1,
-		Deadline: testNow.Add(time.Duration(2) * days).Format(layout),
+		Deadline: testNow.Add(time.Duration(2) * days).Format(pb.TimeLayout),
 	}
 	lab1.ID = 1
 	submission := &pb.Submission{Status: pb.Submission_NONE, AssignmentID: lab1.ID}
@@ -280,7 +279,7 @@ func ExampleEnrollment_GetUsedSlipDays() {
 func TestSlipDaysWGracePeriod(t *testing.T) {
 	lab := a(0)
 	lab.ID = 1
-	timeOfDeadline, err := time.Parse(layout, lab.Deadline)
+	timeOfDeadline, err := time.Parse(pb.TimeLayout, lab.Deadline)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/assignments/assignments_parser.go
+++ b/assignments/assignments_parser.go
@@ -94,7 +94,7 @@ func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 }
 
 func FixDeadline(in string) string {
-	wantLayout := "2006-01-02T15:04:05"
+	wantLayout := pb.TimeLayout
 	acceptedLayouts := []string{
 		"2006-1-2T15:04:05",
 		"2006-1-2 15:04:05",

--- a/ci/results.go
+++ b/ci/results.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/autograde/quickfeed/log"
 	"go.uber.org/zap"
@@ -58,7 +59,7 @@ func ExtractResult(logger *zap.SugaredLogger, out, secret string, execTime time.
 		Scores: scores,
 		BuildInfo: &BuildInfo{
 			BuildID:   atomic.AddInt64(globalBuildID, 1),
-			BuildDate: time.Now().Format("2006-01-02T15:04:05"),
+			BuildDate: time.Now().Format(pb.TimeLayout),
 			BuildLog:  strings.Join(filteredLog, "\n"),
 			ExecTime:  execTime.Milliseconds(),
 		},

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -15,7 +15,6 @@ import (
 
 const (
 	scriptPath = "ci/scripts"
-	layout     = "2006-01-02T15:04:05"
 )
 
 // RunData stores CI data
@@ -140,7 +139,7 @@ func randomSecret() string {
 }
 
 func updateSlipDays(logger *zap.SugaredLogger, db database.Database, assignment *pb.Assignment, submission *pb.Submission, buildDate string) {
-	buildTime, err := time.Parse(layout, buildDate)
+	buildTime, err := time.Parse(pb.TimeLayout, buildDate)
 	if err != nil {
 		logger.Errorf("Failed to parse time from string (%s)", buildDate)
 	}

--- a/web/courses.go
+++ b/web/courses.go
@@ -12,8 +12,6 @@ import (
 	"github.com/autograde/quickfeed/scm"
 )
 
-var layout = "2006-01-02T15:04:05"
-
 // getCourses returns all courses.
 func (s *AutograderService) getCourses() (*pb.Courses, error) {
 	courses, err := s.db.GetCourses()
@@ -270,7 +268,7 @@ func (s *AutograderService) updateSubmission(courseID, submissionID uint64, stat
 
 	// if approving previously unapproved submission
 	if status == pb.Submission_APPROVED && submission.Status != pb.Submission_APPROVED {
-		submission.ApprovedDate = time.Now().Format(layout)
+		submission.ApprovedDate = time.Now().Format(pb.TimeLayout)
 		if err := s.setLastApprovedAssignment(submission, courseID); err != nil {
 			return err
 		}
@@ -573,7 +571,7 @@ func (s *AutograderService) extractSubmissionDate(submission *pb.Submission, sub
 		s.logger.Errorf("Failed to unmarshal build info %s: %s", buildInfoString, err)
 	}
 
-	currentSubmissionDate, err := time.Parse(layout, buildInfo.BuildDate)
+	currentSubmissionDate, err := time.Parse(pb.TimeLayout, buildInfo.BuildDate)
 	if err != nil {
 		s.logger.Errorf("Failed extracting submission date: %s", err)
 	} else if currentSubmissionDate.After(submissionDate) {

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -180,7 +180,7 @@ func (wh GitHubWebHook) runAssignmentTests(assignment *pb.Assignment, repo *pb.R
 func (wh GitHubWebHook) recordSubmissionWithoutTests(data *ci.RunData) {
 	noTestBuildInfo, err := json.Marshal(&ci.BuildInfo{
 		BuildID:   0,
-		BuildDate: time.Now().Format("2006-01-02T15:04:05"),
+		BuildDate: time.Now().Format(pb.TimeLayout),
 		BuildLog:  "No automated tests for this assignment",
 		ExecTime:  1,
 	})


### PR DESCRIPTION
- Added `TimeLayout` in new file `ag/consts.go`.
- Replaced layout constants in `slipdays_tests.go` & `assignments.go`.