### PR TITLE
Basic authentication & updated envoy config

### DIFF
--- a/ag/validation.go
+++ b/ag/validation.go
@@ -59,7 +59,7 @@ func Interceptor(logger *zap.Logger, userMap map[string]uint64) grpc.UnaryServer
 		if !ok {
 			return nil, errors.New("Could not grab metadata from context")
 		}
-		meta, err := UserValidation(meta, userMap)
+		meta, err := userValidation(meta, userMap)
 		if err != nil {
 			return nil, err
 		}
@@ -82,20 +82,20 @@ func Interceptor(logger *zap.Logger, userMap map[string]uint64) grpc.UnaryServer
 	}
 }
 
-// Returns modified metadata containing a valid user. Returns an error if the user is not authenticated.
-func UserValidation(meta metadata.MD, userMap map[string]uint64) (metadata.MD, error) {
-	token := meta.Get(Cookie)
+// userValidation returns modified metadata containing a valid user. An error is returned if the user is not authenticated.
+func userValidation(meta metadata.MD, userMap map[string]uint64) (metadata.MD, error) {
+	cookie := meta.Get(Cookie)
 
-	if len(token) > 0 {
-		token := token[0]
-		user := userMap[token]
-		if user == 0 {
-			return nil, errors.New("Could not associate token with a user")
-		}
-		meta.Set(UserKey, strconv.FormatUint(user, 10))
-	} else {
+	if len(cookie) == 0 {
 		return nil, errors.New("Request does not contain a session token")
 	}
+	token := cookie[0]
+	user := userMap[token]
+	if user == 0 {
+		return nil, errors.New("Could not associate token with a user")
+	}
+	meta.Set(UserKey, strconv.FormatUint(user, 10))
+
 	return meta, nil
 }
 

--- a/ag/validation.go
+++ b/ag/validation.go
@@ -15,8 +15,6 @@ import (
 
 // MaxWait is the maximum time a request is allowed to stay open before aborting.
 const MaxWait = 2 * time.Minute
-const Cookie = "cookie"
-const UserKey = "user"
 
 type validator interface {
 	IsValid() bool

--- a/ag/validation.go
+++ b/ag/validation.go
@@ -58,12 +58,16 @@ func Interceptor(logger *zap.Logger, userMap map[string]uint64) grpc.UnaryServer
 			return nil, errors.New("Could not grab metadata from context")
 		}
 
-		token := meta.Get("cookie")[0]
-		if userMap[token] == 0 {
-			return nil, errors.New("Could not associate token with a user")
+		if len(meta.Get("cookie")) > 0 {
+			token := meta.Get("cookie")[0]
+			if userMap[token] == 0 {
+				return nil, errors.New("Could not associate token with a user")
+			}
+			meta.Set("user", strconv.FormatUint(userMap[token], 10))
+			ctx = metadata.NewOutgoingContext(ctx, meta)
+		} else {
+			return nil, errors.New("x")
 		}
-		meta.Set("user", strconv.FormatUint(userMap[token], 10))
-		ctx = metadata.NewOutgoingContext(ctx, meta)
 
 		// if response has information on remote ID, it will be removed
 		resp, err := handler(ctx, req)

--- a/envoy/envoy-test.yaml
+++ b/envoy/envoy-test.yaml
@@ -1,0 +1,127 @@
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+    # Redirects all traffic coming from port 80 to port 443 for SSL
+  - name: http_to_https_redirect
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 80 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          use_remote_address: true
+          xff_num_trusted_hops: 0
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: 
+                - "*"
+              routes:
+              - match: { prefix: "/"}
+                redirect:
+                  port_redirect: 443
+                  https_redirect: true
+          http_filters:
+          - name: envoy.filters.http.router
+
+    # HTTPS Gateway for the frontend server
+  
+  - name: https_server_gateway
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 443 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          use_remote_address: true
+          xff_num_trusted_hops: 0
+          codec_type: auto
+          stat_prefix: ingress_http
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: 
+                # Replace domain with your domain
+                - "www.xini.no"
+              routes:
+              - match: { prefix: "/ag.AutograderService/"}
+                route: 
+                  cluster: grpc_service
+              - match: { prefix: "/"}
+                route:
+                  cluster: web_service
+              - match: {prefix: "/auth/github/callback"}
+                route: { cluster: web_service }
+                
+              cors:
+                allow_origin_string_match:
+                  - prefix: "*"
+                allow_headers: access-control-allow-origin
+          http_filters:
+          - name: envoy.filters.http.grpc_web
+          - name: envoy.filters.http.cors
+          - name: envoy.filters.http.router
+          http_protocol_options: { accept_http_10: true}
+      transport_socket:
+        name: envoy.transport_socket.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+          common_tls_context:
+            # Replace certificate with your certificates
+            tls_certificates:
+              certificate_chain:
+                filename: /etc/letsencrypt/live/www.xini.no/fullchain.pem
+              private_key:
+                filename: /etc/letsencrypt/live/www.xini.no/privkey.pem
+
+
+    # Gateway for the AutograderService gRPC server
+
+  clusters:
+  - name: grpc_service
+    connect_timeout: 1500s
+    type: logical_dns
+    http2_protocol_options: {}
+    lb_policy: round_robin
+    common_http_protocol_options:
+      idle_timeout: 7200s
+    upstream_connection_options:
+        tcp_keepalive:
+          keepalive_probes: 1
+          keepalive_time: 10
+          keepalive_interval: 10
+    load_assignment:
+      cluster_name: cluster_0
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: localhost
+                    # Replace this port with the gRPC server listening port (grpc.addr)
+                    port_value: 9090
+  - name: web_service
+    connect_timeout: 15s
+    type: strict_dns
+    dns_lookup_family: v4_only
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: cluster_1
+      endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: localhost
+                  # Change this to the http.addr you use
+                  port_value: 8081

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to start tcp listener: %v\n", err)
 	}
-	opt := grpc.UnaryInterceptor(pb.Interceptor(logger))
+	opt := grpc.UnaryInterceptor(pb.Interceptor(logger, auth.TokenToUserMap))
 	grpcServer := grpc.NewServer(opt)
 
 	// Create a HTTP server for prometheus.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -8,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/autograde/quickfeed/ci"
 	"github.com/autograde/quickfeed/web"
@@ -20,6 +23,7 @@ import (
 
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -114,7 +118,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to start tcp listener: %v\n", err)
 	}
-	opt := grpc.UnaryInterceptor(pb.Interceptor(logger, auth.TokenToUserMap))
+	opt := grpc.ChainUnaryInterceptor(UserVerifier(), pb.Interceptor(logger))
 	grpcServer := grpc.NewServer(opt)
 
 	// Create a HTTP server for prometheus.
@@ -132,4 +136,33 @@ func main() {
 	if err := grpcServer.Serve(lis); err != nil {
 		log.Fatalf("failed to start grpc server: %v\n", err)
 	}
+}
+
+const Cookie = "cookie"
+
+func UserVerifier() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		meta, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, errors.New("Could not grab metadata from context")
+		}
+		meta, err := userValidation(meta)
+		if err != nil {
+			return nil, err
+		}
+		ctx = metadata.NewOutgoingContext(ctx, meta)
+		resp, err := handler(ctx, req)
+		return resp, err
+	}
+}
+
+// userValidation returns modified metadata containing a valid user. An error is returned if the user is not authenticated.
+func userValidation(meta metadata.MD) (metadata.MD, error) {
+	for _, cookie := range meta.Get(Cookie) {
+		if user := auth.TokenStore.Get(cookie); user > 0 {
+			meta.Set(auth.UserKey, strconv.FormatUint(user, 10))
+			return meta, nil
+		}
+	}
+	return nil, errors.New("Request does not contain a valid session cookie.")
 }

--- a/main.go
+++ b/main.go
@@ -138,8 +138,6 @@ func main() {
 	}
 }
 
-const Cookie = "cookie"
-
 func UserVerifier() grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		meta, ok := metadata.FromIncomingContext(ctx)
@@ -158,7 +156,7 @@ func UserVerifier() grpc.UnaryServerInterceptor {
 
 // userValidation returns modified metadata containing a valid user. An error is returned if the user is not authenticated.
 func userValidation(meta metadata.MD) (metadata.MD, error) {
-	for _, cookie := range meta.Get(Cookie) {
+	for _, cookie := range meta.Get(auth.Cookie) {
 		if user := auth.TokenStore.Get(cookie); user > 0 {
 			meta.Set(auth.UserKey, strconv.FormatUint(user, 10))
 			return meta, nil

--- a/public/src/index.tsx
+++ b/public/src/index.tsx
@@ -299,12 +299,10 @@ async function main(): Promise<void> {
     const DEBUG_SERVER = "DEBUG_SERVER";
 
     let curRunning = DEBUG_SERVER;
-    let grpcPort = ":8080";
 
     if (window.location.host.match("localhost")
         || localStorage.getItem("debug")) {
         curRunning = DEBUG_BROWSER;
-        grpcPort = "";
     }
 
     const tempData = new TempDataProvider();
@@ -316,7 +314,7 @@ async function main(): Promise<void> {
 
     if (curRunning === DEBUG_SERVER) {
         const httpHelper = new HttpHelper("/api/v1");
-        const grpcHelper = new GrpcManager(grpcPort);
+        const grpcHelper = new GrpcManager();
         const serverData = new ServerProvider(httpHelper, grpcHelper, logMan.createLogger("ServerProvider"));
         userMan = new UserManager(serverData, logMan.createLogger("UserManager"));
         grpcHelper.setUserMan(userMan);

--- a/public/src/managers/GRPCManager.ts
+++ b/public/src/managers/GRPCManager.ts
@@ -55,8 +55,8 @@ export class GrpcManager {
     private agService: AutograderServiceClient;
     private userMan: UserManager;
 
-    constructor(port: string) {
-        this.agService = new AutograderServiceClient("https://" + window.location.hostname + port, null, null);
+    constructor() {
+        this.agService = new AutograderServiceClient("https://" + window.location.hostname, null, null);
     }
 
     public setUserMan(man: UserManager) {

--- a/public/src/managers/GRPCManager.ts
+++ b/public/src/managers/GRPCManager.ts
@@ -360,7 +360,7 @@ export class GrpcManager {
             if (currentUser != null) {
                 userID = currentUser.getId().toString();
             }
-            method.call(this.agService, request, { "custom-header-1": "value1", "user": userID },
+            method.call(this.agService, request, {},
                 (err: grpcWeb.Error, response: T) => {
                     if (err) {
                         if (err.code !== grpcWeb.StatusCode.OK) {

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -326,7 +326,7 @@ func AccessControl(logger *zap.Logger, db database.Database, scms *Scms) echo.Mi
 				return echo.NewHTTPError(http.StatusBadRequest, err)
 			}
 
-			token, err := c.Cookie("session")
+			token, err := c.Cookie(SessionKey)
 			if err != nil {
 				return err
 			}

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -25,6 +25,7 @@ const (
 	SessionKey       = "session"
 	GothicSessionKey = "_gothic_session"
 	UserKey          = "user"
+	Cookie           = "cookie"
 )
 
 // Query keys.
@@ -46,7 +47,7 @@ func newUserSession(id uint64) *UserSession {
 	}
 }
 
-// TokenToUserMap
+// UserToken holds a map from session cookies to user IDs.
 type UserToken struct {
 	store map[string]uint64
 }


### PR DESCRIPTION
This PR introduces an updated envoy configuration that allows gRPC and regular HTTP communication to occur on a single port. This should remove the need for documentation introduced in #448 .

The PR also introduces basic authentication by session token.
