### PR TITLE
Make target to compile ag.proto for Swift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ OS					:= $(shell echo $(shell uname -s) | tr A-Z a-z)
 ARCH				:= $(shell uname -m)
 tmpdir				:= tmp
 proto-path			:= public/proto
+proto-swift-path	:= ../quickfeed-swiftui/Quickfeed/Proto
 grpcweb-ver			:= 1.2.0
 protoc-grpcweb		:= protoc-gen-grpc-web
 protoc-grpcweb-long	:= $(protoc-grpcweb)-$(grpcweb-ver)-$(OS)-$(ARCH)
@@ -58,6 +59,17 @@ proto:
 	$(proto-path)/ag/ag_pb.d.ts \
 	$(proto-path)/ag/AgServiceClientPb.ts
 	@cd public && npm run tsc -- proto/ag/AgServiceClientPb.ts
+
+proto-swift:
+	@echo "Compiling Autograders proto definitions for swift"
+	@protoc \
+	-I . \
+	-I `go list -m -f {{.Dir}} github.com/alta/protopatch` \
+	-I `go list -m -f {{.Dir}} google.golang.org/protobuf` \
+	--swift_out=:$(proto-swift-path) \
+	--grpc-swift_out=$(proto-swift-path) \
+	ag/ag.proto
+	
 
 brew:
     ifeq (, $(shell which brew))

--- a/ag/ag.proto
+++ b/ag/ag.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package ag;
 option go_package = "github.com/autograde/quickfeed/ag";
+option swift_prefix="";
 
 import "patch/go.proto";
 


### PR DESCRIPTION
- Make target that outputs `ag.pb.swift` & `ag.grpc.swift` to the path specified in `proto-swift-path`.
- Adds an option in `ag.proto` to prevent generated Swift structures to be prefixed with `Ag_`.

Closes autograde/quickfeed-swiftui#75