### PR TITLE
Replace %w and %s with %v for error logging

### DIFF
--- a/assignments/assignments.go
+++ b/assignments/assignments.go
@@ -18,12 +18,12 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, db database.Database, repo *
 	logger.Debugf("Updating %s from '%s' repository", course.GetCode(), pb.TestsRepo)
 	s, err := scm.NewSCMClient(logger, course.GetProvider(), course.GetAccessToken())
 	if err != nil {
-		logger.Errorf("Failed to create SCM Client: %w", err)
+		logger.Errorf("Failed to create SCM Client: %v", err)
 		return
 	}
 	assignments, err := FetchAssignments(context.Background(), s, course)
 	if err != nil {
-		logger.Errorf("Failed to fetch assignments from '%s' repository: %w", pb.TestsRepo, err)
+		logger.Errorf("Failed to fetch assignments from '%s' repository: %v", pb.TestsRepo, err)
 		return
 	}
 	for _, assignment := range assignments {
@@ -34,7 +34,7 @@ func UpdateFromTestsRepo(logger *zap.SugaredLogger, db database.Database, repo *
 		for _, assignment := range assignments {
 			logger.Debugf("Failed to update database for: %v", assignment)
 		}
-		logger.Errorf("Failed to update assignments in database: %w", err)
+		logger.Errorf("Failed to update assignments in database: %v", err)
 		return
 	}
 

--- a/web/courses.go
+++ b/web/courses.go
@@ -440,7 +440,7 @@ func (s *AutograderService) enrollStudent(ctx context.Context, sc scm.SCM, enrol
 	if enrolled.Status == pb.Enrollment_TEACHER {
 		err = revokeTeacherStatus(ctx, sc, course.GetOrganizationPath(), user.GetLogin())
 		if err != nil {
-			s.logger.Errorf("Revoking teacher status failed for user %s and course %s: %s", user.Login, course.Name, err)
+			s.logger.Errorf("Failed to revoke teacher status for user %s and course %s: %v", user.Login, course.Name, err)
 		}
 	} else {
 
@@ -452,7 +452,7 @@ func (s *AutograderService) enrollStudent(ctx context.Context, sc scm.SCM, enrol
 		// create user repo, user team, and add user to students team
 		repo, err := updateReposAndTeams(ctx, sc, course, user.GetLogin(), pb.Enrollment_STUDENT)
 		if err != nil {
-			s.logger.Errorf("failed to update repos or team membersip for student %s: %s", user.Login, err.Error())
+			s.logger.Errorf("Failed to update repos or team membership for student %s: %v", user.Login, err)
 			return err
 		}
 		s.logger.Debug("Enrolling student: ", user.GetLogin(), " repo and team update done")
@@ -481,7 +481,7 @@ func (s *AutograderService) enrollTeacher(ctx context.Context, sc scm.SCM, enrol
 
 	// make owner, remove from students, add to teachers
 	if _, err := updateReposAndTeams(ctx, sc, course, user.GetLogin(), pb.Enrollment_TEACHER); err != nil {
-		s.logger.Errorf("failed to update team membership for teacher %s: %s", user.Login, err.Error())
+		s.logger.Errorf("Failed to update team membership for teacher %s: %v", user.Login, err)
 		return err
 	}
 	return s.db.UpdateEnrollment(&pb.Enrollment{
@@ -568,12 +568,12 @@ func (s *AutograderService) extractSubmissionDate(submission *pb.Submission, sub
 	var buildInfo ci.BuildInfo
 	if err := json.Unmarshal([]byte(buildInfoString), &buildInfo); err != nil {
 		// don't fail the method on a parsing error, just log
-		s.logger.Errorf("Failed to unmarshal build info %s: %s", buildInfoString, err)
+		s.logger.Errorf("Failed to unmarshal build info %s: %v", buildInfoString, err)
 	}
 
 	currentSubmissionDate, err := time.Parse(pb.TimeLayout, buildInfo.BuildDate)
 	if err != nil {
-		s.logger.Errorf("Failed extracting submission date: %s", err)
+		s.logger.Errorf("Failed to parse submission date %s: %v", buildInfo.BuildDate, err)
 	} else if currentSubmissionDate.After(submissionDate) {
 		submissionDate = currentSubmissionDate
 	}

--- a/web/groups.go
+++ b/web/groups.go
@@ -83,7 +83,7 @@ func (s *AutograderService) createGroup(request *pb.Group) (*pb.Group, error) {
 	}
 	// get users of group, check consistency of group request
 	if _, err := s.getGroupUsers(request); err != nil {
-		s.logger.Errorf("CreateGroup: failed to retrieve users for group %s: %s", request.GetName(), err)
+		s.logger.Errorf("CreateGroup: failed to retrieve users for group %s: %v", request.GetName(), err)
 		return nil, err
 	}
 	// create new group and update groupID in enrollment table
@@ -212,7 +212,7 @@ func (s *AutograderService) isValidGroupName(courseID uint64, groupName string) 
 	courseGroups, _ := s.db.GetGroupsByCourse(courseID)
 	for _, group := range courseGroups {
 		if slug.Make(groupName) == slug.Make(group.GetName()) {
-			s.logger.Errorf("failed to create group %s, another group % already exists, both names will result in %s on GitHub", groupName, group.Name, slug.Make(groupName))
+			s.logger.Errorf("Failed to create group %s, another group % already exists, both names will result in %s on GitHub", groupName, group.Name, slug.Make(groupName))
 			return false
 		}
 	}

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -34,14 +34,14 @@ func NewGitHubWebHook(logger *zap.SugaredLogger, db database.Database, runner ci
 func (wh GitHubWebHook) Handle(w http.ResponseWriter, r *http.Request) {
 	payload, err := github.ValidatePayload(r, []byte(wh.secret))
 	if err != nil {
-		wh.logger.Errorf("Error in request body: %w", err)
+		wh.logger.Errorf("Error in request body: %v", err)
 		return
 	}
 	defer r.Body.Close()
 
 	event, err := github.ParseWebHook(github.WebHookType(r), payload)
 	if err != nil {
-		wh.logger.Errorf("Could not parse github webhook: %w", err)
+		wh.logger.Errorf("Could not parse github webhook: %v", err)
 		return
 	}
 	switch e := event.(type) {
@@ -63,14 +63,14 @@ func (wh GitHubWebHook) handlePush(payload *github.PushEvent) {
 
 	repo, err := wh.db.GetRepositoryByRemoteID(uint64(payload.GetRepo().GetID()))
 	if err != nil {
-		wh.logger.Errorf("Failed to get repository from database: %w", err)
+		wh.logger.Errorf("Failed to get repository from database: %v", err)
 		return
 	}
 	wh.logger.Debugf("Received push event for repository %v", repo)
 
 	course, err := wh.db.GetCourseByOrganizationID(repo.OrganizationID)
 	if err != nil {
-		wh.logger.Errorf("Failed to get course from database: %w", err)
+		wh.logger.Errorf("Failed to get course from database: %v", err)
 		return
 	}
 	wh.logger.Debugf("For course(%d)=%v", course.GetID(), course.GetName())
@@ -98,7 +98,7 @@ func (wh GitHubWebHook) handlePush(payload *github.PushEvent) {
 		wh.logger.Debugf("Processing push event for group repo %s", payload.GetRepo().GetName())
 		jobOwner, _, err := wh.db.GetUserByCourse(course, payload.GetSender().GetLogin())
 		if err != nil {
-			wh.logger.Errorf("Failed to find user %s in the course %s: %s", payload.GetSender().GetLogin(), course.GetName(), err)
+			wh.logger.Errorf("Failed to find user %s in course %s: %v", payload.GetSender().GetLogin(), course.GetName(), err)
 			return
 		}
 		wh.updateLastActivityDate(jobOwner.ID, course.ID)
@@ -185,7 +185,7 @@ func (wh GitHubWebHook) recordSubmissionWithoutTests(data *ci.RunData) {
 		ExecTime:  1,
 	})
 	if err != nil {
-		wh.logger.Errorf("Error marshalling build info for %s of course %s for student %s: %s", data.Course.Name, data.Assignment.Name, data.JobOwner, err)
+		wh.logger.Errorf("Failed to marshal build info for course %s, assignment %s for student %s: %v", data.Course.Name, data.Assignment.Name, data.JobOwner, err)
 		return
 	}
 	newSubmission := &pb.Submission{
@@ -196,11 +196,10 @@ func (wh GitHubWebHook) recordSubmissionWithoutTests(data *ci.RunData) {
 		GroupID:      data.Repo.GroupID,
 	}
 	if err := wh.db.CreateSubmission(newSubmission); err != nil {
-		wh.logger.Errorf("Failed to save submission for user ID %s for assignment ID %d: %s", data.JobOwner, data.Assignment.ID, err)
+		wh.logger.Errorf("Failed to save submission for user %s, assignment %d: %v", data.JobOwner, data.Assignment.ID, err)
 		return
 	}
 	wh.logger.Debugf("Saved manual review submission for user %s for assignment %d", data.JobOwner, data.Assignment.ID)
-
 }
 
 // updateLastActivityDate sets a current date as a last activity date of the student
@@ -213,6 +212,6 @@ func (wh GitHubWebHook) updateLastActivityDate(userID, courseID uint64) {
 	}
 
 	if err := wh.db.UpdateEnrollment(query); err != nil {
-		wh.logger.Errorf("Failed to update the last activity date for user %d: %s", userID, err)
+		wh.logger.Errorf("Failed to update the last activity date for user %d: %v", userID, err)
 	}
 }


### PR DESCRIPTION
This replaces %w and %s in error printing with %v. Printing with %w gives useless output.
%w should only be used to return errors for chaining via e.g., fmt.Errorf("... : %w", err).

This also replaces status.Errorf() with status.Error(), since none of our uses actually supplied a format string.

Fixes #455.

