### PR TITLE
Added IsManual() and HasTests() for Assignment type

### DIFF
--- a/ag/assignment.go
+++ b/ag/assignment.go
@@ -12,8 +12,8 @@ const (
 // SinceDeadline returns the duration since the deadline.
 // A positive duration means the deadline has passed, whereas
 // a negative duration means the deadline has not yet passed.
-func (m *Assignment) SinceDeadline(now time.Time) (time.Duration, error) {
-	deadline, err := time.ParseInLocation(TimeLayout, m.GetDeadline(), now.Location())
+func (a *Assignment) SinceDeadline(now time.Time) (time.Duration, error) {
+	deadline, err := time.ParseInLocation(TimeLayout, a.GetDeadline(), now.Location())
 	if err != nil {
 		// this should not happen if deadlines are parsed and recorded correctly
 		return zero, err
@@ -24,13 +24,23 @@ func (m *Assignment) SinceDeadline(now time.Time) (time.Duration, error) {
 // IsApproved returns true if this assignment is already approved for the
 // latest submission, or if the score of the latest submission is sufficient
 // to autoapprove the assignment.
-func (m *Assignment) IsApproved(latest *Submission, score uint32) bool {
+func (a *Assignment) IsApproved(latest *Submission, score uint32) bool {
 	// keep approved status if already approved
 	approved := latest.GetStatus() == Submission_APPROVED
-	if m.GetAutoApprove() && score >= m.GetScoreLimit() {
+	if a.GetAutoApprove() && score >= a.GetScoreLimit() {
 		approved = true
 	}
 	return approved
+}
+
+// IsManual returns true if the assignment is manually graded.
+func (a *Assignment) IsManual() bool {
+	return len(a.GetGradingBenchmarks()) > 0
+}
+
+// HasTests returns true if the assignment has tests to be executed by QuickFeed's CI.
+func (a *Assignment) HasTests() bool {
+	return !a.IsManual()
 }
 
 // CloneWithoutSubmissions returns a deep copy of the given assignment

--- a/ag/assignment_test.go
+++ b/ag/assignment_test.go
@@ -1,0 +1,42 @@
+package ag_test
+
+import (
+	"testing"
+
+	pb "github.com/autograde/quickfeed/ag"
+)
+
+func TestIsManual(t *testing.T) {
+	assignmentWithoutBenchmarks := &pb.Assignment{
+		ID:       1,
+		CourseID: 24,
+	}
+	got := assignmentWithoutBenchmarks.IsManual()
+	expected := false
+	if got != expected {
+		t.Errorf("IsManual()=%t, expected %t", got, expected)
+	}
+
+	got = assignmentWithoutBenchmarks.HasTests()
+	expected = true
+	if got != expected {
+		t.Errorf("HasTests()=%t, expected %t", got, expected)
+	}
+
+	assignmentWithBenchmarks := &pb.Assignment{
+		ID:                1,
+		CourseID:          24,
+		GradingBenchmarks: []*pb.GradingBenchmark{{}},
+	}
+	got = assignmentWithBenchmarks.IsManual()
+	expected = true
+	if got != expected {
+		t.Errorf("IsManual()=%t, expected %t", got, expected)
+	}
+
+	got = assignmentWithBenchmarks.HasTests()
+	expected = false
+	if got != expected {
+		t.Errorf("HasTests()=%t, expected %t", got, expected)
+	}
+}


### PR DESCRIPTION
This adds IsManual() and HasTests() for the Assignment type, which should allow us to replace the SkipTests field.
Although we may need to implement similar functionality on the different frontends.
Follow up commits should fix the current frontend code.

