### PR TITLE
Removed defunct script.path command line argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,13 +61,12 @@ var reg = prometheus.NewRegistry()
 
 func main() {
 	var (
-		baseURL    = flag.String("service.url", "", "base service DNS name")
-		dbFile     = flag.String("database.file", "qf.db", "database file")
-		public     = flag.String("http.public", "public", "path to content to serve")
-		httpAddr   = flag.String("http.addr", ":8081", "HTTP listen address")
-		grpcAddr   = flag.String("grpc.addr", ":9090", "gRPC listen address")
-		scriptPath = flag.String("script.path", "ci/scripts", "path to continuous integration scripts")
-		fake       = flag.Bool("provider.fake", false, "enable fake provider")
+		baseURL  = flag.String("service.url", "", "base service DNS name")
+		dbFile   = flag.String("database.file", "qf.db", "database file")
+		public   = flag.String("http.public", "public", "path to content to serve")
+		httpAddr = flag.String("http.addr", ":8081", "HTTP listen address")
+		grpcAddr = flag.String("grpc.addr", ":9090", "gRPC listen address")
+		fake     = flag.Bool("provider.fake", false, "enable fake provider")
 	)
 	flag.Parse()
 
@@ -96,7 +95,7 @@ func main() {
 	defer runner.Close()
 
 	agService := web.NewAutograderService(logger, db, scms, bh, runner)
-	go web.New(agService, *public, *httpAddr, *scriptPath, *fake)
+	go web.New(agService, *public, *httpAddr, *fake)
 
 	lis, err := net.Listen("tcp", *grpcAddr)
 	if err != nil {

--- a/web/webserver.go
+++ b/web/webserver.go
@@ -29,7 +29,7 @@ var (
 )
 
 // New starts a new web server
-func New(ags *AutograderService, public, httpAddr, scriptPath string, fake bool) {
+func New(ags *AutograderService, public, httpAddr string, fake bool) {
 	entryPoint := filepath.Join(public, "index.html")
 	if _, err := os.Stat(entryPoint); os.IsNotExist(err) {
 		ags.logger.Fatalf("file not found %s", entryPoint)
@@ -40,7 +40,7 @@ func New(ags *AutograderService, public, httpAddr, scriptPath string, fake bool)
 	e := newServer(ags.logger, store)
 
 	enabled := enableProviders(ags.logger, ags.bh.BaseURL, fake)
-	registerWebhooks(ags, e, enabled, scriptPath)
+	registerWebhooks(ags, e, enabled)
 	registerAuth(ags, e)
 
 	registerFrontend(e, entryPoint, public)
@@ -112,7 +112,7 @@ func enableProviders(l *zap.SugaredLogger, baseURL string, fake bool) map[string
 	return enabled
 }
 
-func registerWebhooks(ags *AutograderService, e *echo.Echo, enabled map[string]bool, scriptPath string) {
+func registerWebhooks(ags *AutograderService, e *echo.Echo, enabled map[string]bool) {
 	if enabled["github"] {
 		ghHook := hooks.NewGitHubWebHook(ags.logger, ags.db, ags.runner, ags.bh.Secret)
 		e.POST("/hook/github/events", func(c echo.Context) error {
@@ -121,7 +121,7 @@ func registerWebhooks(ags *AutograderService, e *echo.Echo, enabled map[string]b
 		})
 	}
 	if enabled["gitlab"] {
-		//TODO(meling) fix gitlab
+		// TODO(meling) fix gitlab
 		glHook := hooks.NewGitHubWebHook(ags.logger, ags.db, ags.runner, ags.bh.Secret)
 		e.POST("/hook/gitlab/events", func(c echo.Context) error {
 			glHook.Handle(c.Response(), c.Request())


### PR DESCRIPTION
This removes the `script.path` command-line argument that has never been used in the code; the current implementation has a hardcoded `scriptPath` const. Ideally, we should implement #285 to allow course-dependent script paths, but that's for another PR.

Fixes #454.

