### PR TITLE
Internal package for test helpers; includes TestDB()

### DIFF
--- a/database/db_user_test.go
+++ b/database/db_user_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/autograde/quickfeed/internal"
 )
 
 func TestGormDBUpdateAccessToken(t *testing.T) {
@@ -37,7 +38,7 @@ func TestGormDBUpdateAccessToken(t *testing.T) {
 		}
 	)
 
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	var user pb.User

--- a/database/gormdb_assignment_test.go
+++ b/database/gormdb_assignment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/autograde/quickfeed/internal"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
@@ -13,7 +14,7 @@ import (
 )
 
 func TestGormDBGetAssignment(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	if _, err := db.GetAssignmentsByCourse(10, false); err != gorm.ErrRecordNotFound {
@@ -26,7 +27,7 @@ func TestGormDBGetAssignment(t *testing.T) {
 }
 
 func TestGormDBCreateAssignmentNoRecord(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	assignment := pb.Assignment{
@@ -41,7 +42,7 @@ func TestGormDBCreateAssignmentNoRecord(t *testing.T) {
 }
 
 func TestGormDBCreateAssignment(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	user := createFakeUser(t, db, 10)
@@ -77,7 +78,7 @@ func TestGormDBCreateAssignment(t *testing.T) {
 }
 
 func TestUpdateAssignment(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{}
@@ -141,7 +142,7 @@ func TestUpdateAssignment(t *testing.T) {
 }
 
 func TestGetAssignmentsWithSubmissions(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	// create teacher, course, user (student) and assignment
@@ -231,7 +232,7 @@ func TestGetAssignmentsWithSubmissions(t *testing.T) {
 }
 
 func TestUpdateBenchmarks(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{}

--- a/database/gormdb_group_test.go
+++ b/database/gormdb_group_test.go
@@ -10,6 +10,7 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
+	"github.com/autograde/quickfeed/internal"
 )
 
 var createGroupTests = []struct {
@@ -122,7 +123,7 @@ var groupWithUsers = func(cid uint64, uids ...uint64) *pb.Group {
 func TestGormDBCreateAndGetGroup(t *testing.T) {
 	for _, test := range createGroupTests {
 		t.Run(test.name, func(t *testing.T) {
-			db, cleanup := setup(t)
+			db, cleanup := internal.TestDB(t)
 
 			teacher := createFakeUser(t, db, 10)
 			var course pb.Course
@@ -221,7 +222,7 @@ func TestGormDBCreateAndGetGroup(t *testing.T) {
 }
 
 func TestGormDBCreateGroupTwice(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)
@@ -277,7 +278,7 @@ func TestGormDBCreateGroupTwice(t *testing.T) {
 }
 
 func TestGetGroupsByCourse(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)

--- a/database/gormdb_submission_test.go
+++ b/database/gormdb_submission_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/autograde/quickfeed/ag"
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
+	"github.com/autograde/quickfeed/internal"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"gorm.io/gorm"
 )
 
 func TestGormDBGetSubmissionForUser(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 	query := &pb.Submission{AssignmentID: 10, UserID: 10}
 	if _, err := db.GetSubmission(query); err != gorm.ErrRecordNotFound {
@@ -57,7 +58,7 @@ func setupCourseAssignment(t *testing.T, db database.Database) (*pb.User, *pb.Co
 }
 
 func TestGormDBUpdateSubmissionZeroScore(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 	user, course, assignment := setupCourseAssignment(t, db)
 
@@ -115,7 +116,7 @@ func TestGormDBUpdateSubmissionZeroScore(t *testing.T) {
 }
 
 func TestGormDBUpdateSubmission(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 	user, course, assignment := setupCourseAssignment(t, db)
 
@@ -181,7 +182,7 @@ func TestGormDBUpdateSubmission(t *testing.T) {
 }
 
 func TestGormDBGetNonExistingSubmissions(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 	if _, err := db.GetLastSubmissions(10, &pb.Submission{UserID: 10}); err != gorm.ErrRecordNotFound {
 		t.Errorf("have error '%v' wanted '%v'", err, gorm.ErrRecordNotFound)
@@ -189,7 +190,7 @@ func TestGormDBGetNonExistingSubmissions(t *testing.T) {
 }
 
 func TestGormDBInsertSubmissions(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	// expected to fail with record not found
@@ -239,7 +240,7 @@ func TestGormDBInsertSubmissions(t *testing.T) {
 }
 
 func TestGormDBGetInsertSubmissions(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/autograde/quickfeed
 
-go 1.14
+go 1.16
 
 require (
 	github.com/360EntSecGroup-Skylar/excelize v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -238,7 +238,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/d2g/dhcp4 v0.0.0-20170904100407-a1d1b6c41b1c/go.mod h1:Ct2BUK8SB0YC1SMSibvLzxjeJLnrYEVLULFNiHY9YfQ=

--- a/internal/test_helper.go
+++ b/internal/test_helper.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/autograde/quickfeed/database"
+	"github.com/autograde/quickfeed/log"
+)
+
+// TestDB returns a test database and close function.
+// This function should only be as a test helper.
+func TestDB(t *testing.T) (database.Database, func()) {
+	t.Helper()
+
+	f, err := ioutil.TempFile(t.TempDir(), "test.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		t.Fatal(err)
+	}
+
+	db, err := database.NewGormDB(f.Name(), log.Zap(true))
+	if err != nil {
+		os.Remove(f.Name())
+		t.Fatal(err)
+	}
+
+	return db, func() {
+		if err := os.Remove(f.Name()); err != nil {
+			t.Error(err)
+		}
+	}
+}

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -1,15 +1,12 @@
 package auth_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"reflect"
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/database"
 	"github.com/autograde/quickfeed/internal"
 	"github.com/autograde/quickfeed/web/auth"
 	"github.com/gorilla/sessions"
@@ -372,33 +369,6 @@ func TestAccessControl(t *testing.T) {
 	// User is logged in.
 	if err := protected(c); err != nil {
 		t.Error(err)
-	}
-}
-
-func setup(t *testing.T) (*database.GormDB, func()) {
-	const (
-		prefix = "testdb"
-	)
-
-	f, err := ioutil.TempFile(os.TempDir(), prefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(f.Name())
-		t.Fatal(err)
-	}
-
-	db, err := database.NewGormDB(f.Name(), zap.NewNop())
-	if err != nil {
-		os.Remove(f.Name())
-		t.Fatal(err)
-	}
-
-	return db, func() {
-		if err := os.Remove(f.Name()); err != nil {
-			t.Error(err)
-		}
 	}
 }
 

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -10,6 +10,7 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
+	"github.com/autograde/quickfeed/internal"
 	"github.com/autograde/quickfeed/web/auth"
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
@@ -87,7 +88,7 @@ func TestOAuth2LoginRedirect(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	authHandler := auth.OAuth2Login(zap.NewNop(), db)
@@ -109,7 +110,7 @@ func TestOAuth2CallbackBadRequest(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	authHandler := auth.OAuth2Callback(zap.NewNop(), db)
@@ -164,7 +165,7 @@ func testPreAuthLoggedIn(t *testing.T, haveSession, existingUser bool, newProvid
 		}
 	}
 
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	if existingUser {
@@ -232,7 +233,7 @@ func TestOAuth2LoginAuthenticated(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	authHandler := auth.OAuth2Login(zap.NewNop(), db)
@@ -295,7 +296,7 @@ func testOAuth2Callback(t *testing.T, existingUser, haveSession bool) {
 		}
 	}
 
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	if existingUser {
@@ -339,7 +340,7 @@ func TestAccessControl(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	// Create a new user.

--- a/web/autograder_service.go
+++ b/web/autograder_service.go
@@ -19,7 +19,7 @@ import (
 // other shared data structures.
 type AutograderService struct {
 	logger *zap.SugaredLogger
-	db     *database.GormDB
+	db     database.Database
 	scms   *auth.Scms
 	bh     BaseHookOptions
 	runner ci.Runner
@@ -27,7 +27,7 @@ type AutograderService struct {
 }
 
 // NewAutograderService returns an AutograderService object.
-func NewAutograderService(logger *zap.Logger, db *database.GormDB, scms *auth.Scms, bh BaseHookOptions, runner ci.Runner) *AutograderService {
+func NewAutograderService(logger *zap.Logger, db database.Database, scms *auth.Scms, bh BaseHookOptions, runner ci.Runner) *AutograderService {
 	return &AutograderService{
 		logger: logger.Sugar(),
 		db:     db,

--- a/web/courses.go
+++ b/web/courses.go
@@ -142,14 +142,14 @@ func (s *AutograderService) getSubmissions(request *pb.SubmissionRequest) (*pb.S
 
 // getAllCourseSubmissions returns all individual lab submissions by students enrolled in the specified course.
 func (s *AutograderService) getAllCourseSubmissions(request *pb.SubmissionsForCourseRequest) (*pb.CourseSubmissions, error) {
-	var getCourseSubFn func(uint64, pb.SubmissionsForCourseRequest_Type) ([]*pb.Assignment, error)
 	// TODO(meling) the NoBuildInfo variant is not in the database.Database interface; but we should avoid two methods for this anyway
+	// var getCourseSubFn func(uint64, pb.SubmissionsForCourseRequest_Type) ([]*pb.Assignment, error)
 	// if request.GetSkipBuildInfo() {
 	// 	getCourseSubFn = s.db.GetCourseAssignmentsWithSubmissionsNoBuildInfo
 	// } else {
 	// 	getCourseSubFn = s.db.GetAssignmentsWithSubmissions
 	// }
-	getCourseSubFn = s.db.GetAssignmentsWithSubmissions
+	getCourseSubFn := s.db.GetAssignmentsWithSubmissions
 	assignments, err := getCourseSubFn(request.GetCourseID(), request.Type)
 	if err != nil {
 		return nil, err

--- a/web/courses.go
+++ b/web/courses.go
@@ -143,11 +143,13 @@ func (s *AutograderService) getSubmissions(request *pb.SubmissionRequest) (*pb.S
 // getAllCourseSubmissions returns all individual lab submissions by students enrolled in the specified course.
 func (s *AutograderService) getAllCourseSubmissions(request *pb.SubmissionsForCourseRequest) (*pb.CourseSubmissions, error) {
 	var getCourseSubFn func(uint64, pb.SubmissionsForCourseRequest_Type) ([]*pb.Assignment, error)
-	if request.GetSkipBuildInfo() {
-		getCourseSubFn = s.db.GetCourseAssignmentsWithSubmissionsNoBuildInfo
-	} else {
-		getCourseSubFn = s.db.GetAssignmentsWithSubmissions
-	}
+	// TODO(meling) the NoBuildInfo variant is not in the database.Database interface; but we should avoid two methods for this anyway
+	// if request.GetSkipBuildInfo() {
+	// 	getCourseSubFn = s.db.GetCourseAssignmentsWithSubmissionsNoBuildInfo
+	// } else {
+	// 	getCourseSubFn = s.db.GetAssignmentsWithSubmissions
+	// }
+	getCourseSubFn = s.db.GetAssignmentsWithSubmissions
 	assignments, err := getCourseSubFn(request.GetCourseID(), request.Type)
 	if err != nil {
 		return nil, err

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/autograde/quickfeed/internal"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/markbates/goth"
@@ -61,7 +62,7 @@ var allCourses = []*pb.Course{
 }
 
 func TestGetCourses(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 10)
@@ -119,7 +120,7 @@ func fakeGothProvider() {
 }
 
 func TestNewCourse(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	// set up fake goth provider (only needs to be done once)
@@ -157,7 +158,7 @@ func TestNewCourse(t *testing.T) {
 }
 
 func TestNewCourseExistingRepos(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 10)
@@ -184,7 +185,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 }
 
 func TestEnrollmentProcess(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -287,7 +288,7 @@ func TestEnrollmentProcess(t *testing.T) {
 }
 
 func TestListCoursesWithEnrollment(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -357,7 +358,7 @@ func TestListCoursesWithEnrollment(t *testing.T) {
 }
 
 func TestListCoursesWithEnrollmentStatuses(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -423,7 +424,7 @@ func TestListCoursesWithEnrollmentStatuses(t *testing.T) {
 }
 
 func TestGetCourse(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -446,7 +447,7 @@ func TestGetCourse(t *testing.T) {
 }
 
 func TestPromoteDemoteRejectTeacher(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	fakeGothProvider()

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -10,12 +10,13 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
+	"github.com/autograde/quickfeed/internal"
 	"github.com/autograde/quickfeed/scm"
 	"github.com/autograde/quickfeed/web"
 )
 
 func TestNewGroup(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -70,7 +71,7 @@ func TestNewGroup(t *testing.T) {
 }
 
 func TestCreateGroupWithMissingFields(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -127,7 +128,7 @@ func TestCreateGroupWithMissingFields(t *testing.T) {
 }
 
 func TestNewGroupTeacherCreator(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -210,7 +211,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 }
 
 func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -271,7 +272,7 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 }
 
 func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	// set up fake goth provider (only needs to be done once)
@@ -458,7 +459,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 }
 
 func TestDeleteGroup(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	testCourse := pb.Course{
@@ -519,7 +520,7 @@ func TestDeleteGroup(t *testing.T) {
 }
 
 func TestGetGroup(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	testCourse := pb.Course{
@@ -568,7 +569,7 @@ func TestGetGroup(t *testing.T) {
 }
 
 func TestPatchGroupStatus(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	course := pb.Course{
@@ -676,7 +677,7 @@ func TestPatchGroupStatus(t *testing.T) {
 }
 
 func TestGetGroupByUserAndCourse(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	course := pb.Course{
@@ -754,7 +755,7 @@ func TestGetGroupByUserAndCourse(t *testing.T) {
 }
 
 func TestDeleteApprovedGroup(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -871,7 +872,7 @@ func TestDeleteApprovedGroup(t *testing.T) {
 }
 
 func TestGetGroups(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	var users []*pb.User

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -7,6 +7,7 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
+	"github.com/autograde/quickfeed/internal"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/autograde/quickfeed/log"
 	"github.com/autograde/quickfeed/scm"
@@ -17,7 +18,7 @@ import (
 )
 
 func TestSubmissionsAccess(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -256,7 +257,7 @@ func TestSubmissionsAccess(t *testing.T) {
 }
 
 func TestApproveSubmission(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -345,7 +346,7 @@ func TestApproveSubmission(t *testing.T) {
 }
 
 func TestGetCourseLabSubmissions(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -527,7 +528,7 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 }
 
 func TestCreateApproveList(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -9,6 +9,7 @@ import (
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
 	"github.com/autograde/quickfeed/database"
+	"github.com/autograde/quickfeed/internal"
 	"github.com/autograde/quickfeed/web"
 	"github.com/autograde/quickfeed/web/auth"
 	"github.com/google/go-cmp/cmp"
@@ -18,7 +19,7 @@ import (
 )
 
 func TestGetSelf(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	_ = createFakeUser(t, db, 1)
@@ -48,7 +49,7 @@ func TestGetSelf(t *testing.T) {
 }
 
 func TestGetUsers(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	_, scms := fakeProviderMap(t)
@@ -97,7 +98,7 @@ var allUsers = []struct {
 }
 
 func TestGetEnrollmentsByCourse(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	var users []*pb.User
@@ -185,7 +186,7 @@ func TestGetEnrollmentsByCourse(t *testing.T) {
 }
 
 func TestEnrollmentsWithoutGroupMembership(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 
 	var users []*pb.User
@@ -273,7 +274,7 @@ func TestEnrollmentsWithoutGroupMembership(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 	firstAdminUser := createFakeUser(t, db, 1)
 	nonAdminUser := createFakeUser(t, db, 11)
@@ -333,7 +334,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestUpdateUserFailures(t *testing.T) {
-	db, cleanup := setup(t)
+	db, cleanup := internal.TestDB(t)
 	defer cleanup()
 	// user := &pb.User{Name: "Test User", StudentID: "11", Email: "test@email", AvatarURL: "url.com"}
 	adminUser := createFakeUser(t, db, 1)

--- a/web/util_test.go
+++ b/web/util_test.go
@@ -1,41 +1,8 @@
 package web_test
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
-
-	"github.com/autograde/quickfeed/database"
-	"go.uber.org/zap"
 )
-
-func setup(t *testing.T) (*database.GormDB, func()) {
-	t.Helper()
-	const (
-		prefix = "testdb"
-	)
-
-	f, err := ioutil.TempFile(os.TempDir(), prefix)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(f.Name())
-		t.Fatal(err)
-	}
-
-	db, err := database.NewGormDB(f.Name(), zap.NewNop())
-	if err != nil {
-		os.Remove(f.Name())
-		t.Fatal(err)
-	}
-
-	return db, func() {
-		if err := os.Remove(f.Name()); err != nil {
-			t.Error(err)
-		}
-	}
-}
 
 func assertCode(t *testing.T, haveCode, wantCode int) {
 	t.Helper()


### PR DESCRIPTION
- Added internal package with TestDB test helper
- Updated database pkg to use internal.TestDB() helper
- Service accept Database interface instead of *GormDB
- Replace util_test.go:setup() with internal.TestDB() helper
- Removed another instance of setup() test helper in web/auth

Fixes #478.

