### PR TITLE
Internal package qtest with test helpers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -106,6 +106,7 @@
         "protobuf",
         "protoc",
         "protoimpl",
+        "qtest",
         "quickfeed",
         "repotoken",
         "run",

--- a/ci/docker_test.go
+++ b/ci/docker_test.go
@@ -3,8 +3,6 @@ package ci_test
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
-	"crypto/sha1"
 	"errors"
 	"fmt"
 	"os"
@@ -13,6 +11,7 @@ import (
 	"time"
 
 	"github.com/autograde/quickfeed/ci"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/log"
 	"github.com/docker/docker/client"
 )
@@ -49,7 +48,7 @@ func TestDocker(t *testing.T) {
 	defer docker.Close()
 
 	out, err := docker.Run(context.Background(), &ci.Job{
-		Name:     "TestDocker-" + randomString(t),
+		Name:     "TestDocker-" + qtest.RandomString(t),
 		Image:    "golang:latest",
 		Commands: []string{script},
 	})
@@ -86,7 +85,7 @@ func TestDockerBuild(t *testing.T) {
 	defer docker.Close()
 
 	out, err := docker.Run(context.Background(), &ci.Job{
-		Name:     "TestDockerBuild-" + randomString(t),
+		Name:     "TestDockerBuild-" + qtest.RandomString(t),
 		Image:    "quickfeed:go",
 		Commands: []string{script},
 	})
@@ -122,7 +121,7 @@ func TestDockerTimeout(t *testing.T) {
 	defer docker.Close()
 
 	out, err := docker.Run(ctx, &ci.Job{
-		Name:     "TestDockerTimeout-" + randomString(t),
+		Name:     "TestDockerTimeout-" + qtest.RandomString(t),
 		Image:    "golang:latest",
 		Commands: []string{script},
 	})
@@ -158,7 +157,7 @@ func TestDockerOpenFileDescriptors(t *testing.T) {
 	errCh := make(chan error, numContainers)
 	for i := 0; i < numContainers; i++ {
 		go func(j int) {
-			name := fmt.Sprintf("TestDockerOpenFileDescritors-%d-%s", j, randomString(t))
+			name := fmt.Sprintf("TestDockerOpenFileDescritors-%d-%s", j, qtest.RandomString(t))
 			out, err := docker.Run(context.Background(), &ci.Job{
 				Name:     name,
 				Image:    "golang:latest",
@@ -195,14 +194,4 @@ func countOpenFiles(t *testing.T) int {
 		t.Fatal(err)
 	}
 	return bytes.Count(out, []byte("\n"))
-}
-
-func randomString(t *testing.T) string {
-	t.Helper()
-	randomness := make([]byte, 10)
-	_, err := rand.Read(randomness)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return fmt.Sprintf("%x", sha1.Sum(randomness))[:6]
 }

--- a/ci/parse_script_test.go
+++ b/ci/parse_script_test.go
@@ -1,13 +1,12 @@
 package ci
 
 import (
-	"crypto/rand"
-	"crypto/sha1"
 	"fmt"
 	"os"
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/autograde/quickfeed/internal/qtest"
 )
 
 // To run this test, please see instructions in the developer guide (dev.md).
@@ -21,11 +20,7 @@ func TestParseScript(t *testing.T) {
 		qfTestOrg      = "qf101"
 		githubUserName = "user"
 	)
-	randomness := make([]byte, 10)
-	if _, err := rand.Read(randomness); err != nil {
-		t.Fatal(err)
-	}
-	randomString := fmt.Sprintf("%x", sha1.Sum(randomness))
+	randomString := qtest.RandomString(t)
 
 	repo := pb.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	info := &AssignmentInfo{

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -135,8 +135,7 @@ func recordResults(logger *zap.SugaredLogger, db database.Database, rData *RunDa
 
 func randomSecret() string {
 	randomness := make([]byte, 10)
-	_, err := rand.Read(randomness)
-	if err != nil {
+	if _, err := rand.Read(randomness); err != nil {
 		panic("couldn't generate randomness")
 	}
 	return fmt.Sprintf("%x", sha1.Sum(randomness))
@@ -145,7 +144,6 @@ func randomSecret() string {
 func updateSlipDays(logger *zap.SugaredLogger, db database.Database, assignment *pb.Assignment, submission *pb.Submission) {
 	buildDate := submission.GetBuildInfo().GetBuildDate()
 	buildTime, err := time.Parse(pb.TimeLayout, buildDate)
-
 	if err != nil {
 		logger.Errorf("Failed to parse time from build date (%s): %v", buildDate, err)
 		return

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/autograde/quickfeed/log"
 	"github.com/autograde/quickfeed/scm"
@@ -75,7 +75,7 @@ func TestRunTests(t *testing.T) {
 }
 
 func TestRecordResults(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	var user pb.User

--- a/ci/run_tests_test.go
+++ b/ci/run_tests_test.go
@@ -2,9 +2,6 @@ package ci
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha1"
-	"fmt"
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
@@ -36,11 +33,7 @@ func TestRunTests(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	randomness := make([]byte, 10)
-	if _, err := rand.Read(randomness); err != nil {
-		t.Fatal(err)
-	}
-	randomString := fmt.Sprintf("%x", sha1.Sum(randomness))
+	randomString := qtest.RandomString(t)
 
 	repo := pb.RepoURL{ProviderURL: "github.com", Organization: qfTestOrg}
 	info := &AssignmentInfo{

--- a/database/db_user_test.go
+++ b/database/db_user_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 )
 
 func TestGormDBUpdateAccessToken(t *testing.T) {
@@ -38,7 +38,7 @@ func TestGormDBUpdateAccessToken(t *testing.T) {
 		}
 	)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	var user pb.User

--- a/database/gormdb_assignment_test.go
+++ b/database/gormdb_assignment_test.go
@@ -45,7 +45,7 @@ func TestGormDBCreateAssignment(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	user := createFakeUser(t, db, 10)
+	user := qtest.CreateFakeUser(t, db, 10)
 	if err := db.CreateCourse(user.ID, &pb.Course{}); err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +82,7 @@ func TestUpdateAssignment(t *testing.T) {
 	defer cleanup()
 
 	course := &pb.Course{}
-	admin := createFakeUser(t, db, 10)
+	admin := qtest.CreateFakeUser(t, db, 10)
 	if err := db.CreateCourse(admin.ID, course); err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestUpdateBenchmarks(t *testing.T) {
 	defer cleanup()
 
 	course := &pb.Course{}
-	admin := createFakeUser(t, db, 10)
+	admin := qtest.CreateFakeUser(t, db, 10)
 	if err := db.CreateCourse(admin.ID, course); err != nil {
 		t.Fatal(err)
 	}

--- a/database/gormdb_assignment_test.go
+++ b/database/gormdb_assignment_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/proto"
@@ -14,7 +14,7 @@ import (
 )
 
 func TestGormDBGetAssignment(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if _, err := db.GetAssignmentsByCourse(10, false); err != gorm.ErrRecordNotFound {
@@ -27,7 +27,7 @@ func TestGormDBGetAssignment(t *testing.T) {
 }
 
 func TestGormDBCreateAssignmentNoRecord(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	assignment := pb.Assignment{
@@ -42,7 +42,7 @@ func TestGormDBCreateAssignmentNoRecord(t *testing.T) {
 }
 
 func TestGormDBCreateAssignment(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	user := createFakeUser(t, db, 10)
@@ -78,7 +78,7 @@ func TestGormDBCreateAssignment(t *testing.T) {
 }
 
 func TestUpdateAssignment(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{}
@@ -142,7 +142,7 @@ func TestUpdateAssignment(t *testing.T) {
 }
 
 func TestGetAssignmentsWithSubmissions(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	// create teacher, course, user (student) and assignment
@@ -232,7 +232,7 @@ func TestGetAssignmentsWithSubmissions(t *testing.T) {
 }
 
 func TestUpdateBenchmarks(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{}

--- a/database/gormdb_group_test.go
+++ b/database/gormdb_group_test.go
@@ -125,7 +125,7 @@ func TestGormDBCreateAndGetGroup(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			db, cleanup := qtest.TestDB(t)
 
-			teacher := createFakeUser(t, db, 10)
+			teacher := qtest.CreateFakeUser(t, db, 10)
 			var course pb.Course
 			if err := db.CreateCourse(teacher.ID, &course); err != nil {
 				t.Fatal(err)
@@ -134,7 +134,7 @@ func TestGormDBCreateAndGetGroup(t *testing.T) {
 			var uids []uint64
 			// create as many users as the desired number of enrollments
 			for i, enrollment := range test.enrollments {
-				user := createFakeUser(t, db, uint64(i))
+				user := qtest.CreateFakeUser(t, db, uint64(i))
 				uids = append(uids, user.ID)
 				if enrollment == uint(pb.Enrollment_PENDING) {
 					continue
@@ -225,7 +225,7 @@ func TestGormDBCreateGroupTwice(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := createFakeUser(t, db, 10)
+	teacher := qtest.CreateFakeUser(t, db, 10)
 	var course pb.Course
 	if err := db.CreateCourse(teacher.ID, &course); err != nil {
 		t.Fatal(err)
@@ -234,7 +234,7 @@ func TestGormDBCreateGroupTwice(t *testing.T) {
 	enrollments := []pb.Enrollment_UserStatus{pb.Enrollment_STUDENT, pb.Enrollment_STUDENT}
 	// create as many users as the desired number of enrollments
 	for i := 0; i < len(enrollments); i++ {
-		user := createFakeUser(t, db, uint64(i))
+		user := qtest.CreateFakeUser(t, db, uint64(i))
 		users = append(users, user)
 		if enrollments[i] == pb.Enrollment_PENDING {
 			continue
@@ -281,7 +281,7 @@ func TestGetGroupsByCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := createFakeUser(t, db, 10)
+	teacher := qtest.CreateFakeUser(t, db, 10)
 	var course pb.Course
 	if err := db.CreateCourse(teacher.ID, &course); err != nil {
 		t.Fatal(err)
@@ -296,7 +296,7 @@ func TestGetGroupsByCourse(t *testing.T) {
 	}
 	// create as many users as the desired number of enrollments
 	for i := 0; i < len(enrollments); i++ {
-		user := createFakeUser(t, db, uint64(i))
+		user := qtest.CreateFakeUser(t, db, uint64(i))
 		users = append(users, user)
 		if enrollments[i] == pb.Enrollment_PENDING {
 			continue

--- a/database/gormdb_group_test.go
+++ b/database/gormdb_group_test.go
@@ -10,7 +10,7 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 )
 
 var createGroupTests = []struct {
@@ -123,7 +123,7 @@ var groupWithUsers = func(cid uint64, uids ...uint64) *pb.Group {
 func TestGormDBCreateAndGetGroup(t *testing.T) {
 	for _, test := range createGroupTests {
 		t.Run(test.name, func(t *testing.T) {
-			db, cleanup := internal.TestDB(t)
+			db, cleanup := qtest.TestDB(t)
 
 			teacher := createFakeUser(t, db, 10)
 			var course pb.Course
@@ -222,7 +222,7 @@ func TestGormDBCreateAndGetGroup(t *testing.T) {
 }
 
 func TestGormDBCreateGroupTwice(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)
@@ -278,7 +278,7 @@ func TestGormDBCreateGroupTwice(t *testing.T) {
 }
 
 func TestGetGroupsByCourse(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)

--- a/database/gormdb_submission_test.go
+++ b/database/gormdb_submission_test.go
@@ -25,7 +25,7 @@ func TestGormDBGetSubmissionForUser(t *testing.T) {
 }
 
 func setupCourseAssignment(t *testing.T, db database.Database) (*pb.User, *pb.Course, *pb.Assignment) {
-	teacher := createFakeUser(t, db, 10)
+	teacher := qtest.CreateFakeUser(t, db, 10)
 	// create a course and an assignment
 	course := &pb.Course{}
 	if err := db.CreateCourse(teacher.ID, course); err != nil {
@@ -40,7 +40,7 @@ func setupCourseAssignment(t *testing.T, db database.Database) (*pb.User, *pb.Co
 	}
 
 	// create user and enroll as student
-	user := createFakeUser(t, db, 11)
+	user := qtest.CreateFakeUser(t, db, 11)
 	if err := db.CreateEnrollment(&pb.Enrollment{
 		UserID:   user.ID,
 		CourseID: course.ID,
@@ -248,7 +248,7 @@ func TestGormDBGetInsertSubmissions(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	teacher := createFakeUser(t, db, 10)
+	teacher := qtest.CreateFakeUser(t, db, 10)
 	// Create course c1 and c2
 	c1 := pb.Course{OrganizationID: 1}
 	if err := db.CreateCourse(teacher.ID, &c1); err != nil {
@@ -260,7 +260,7 @@ func TestGormDBGetInsertSubmissions(t *testing.T) {
 	}
 
 	// create user and enroll as student
-	user := createFakeUser(t, db, 11)
+	user := qtest.CreateFakeUser(t, db, 11)
 
 	// enroll student in course c1
 	if err := db.CreateEnrollment(&pb.Enrollment{

--- a/database/gormdb_submission_test.go
+++ b/database/gormdb_submission_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/autograde/quickfeed/ag"
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGormDBGetSubmissionForUser(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 	query := &pb.Submission{AssignmentID: 10, UserID: 10}
 	if _, err := db.GetSubmission(query); err != gorm.ErrRecordNotFound {
@@ -59,7 +59,7 @@ func setupCourseAssignment(t *testing.T, db database.Database) (*pb.User, *pb.Co
 }
 
 func TestGormDBUpdateSubmissionZeroScore(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 	user, course, assignment := setupCourseAssignment(t, db)
 
@@ -119,7 +119,7 @@ func TestGormDBUpdateSubmissionZeroScore(t *testing.T) {
 }
 
 func TestGormDBUpdateSubmission(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 	user, course, assignment := setupCourseAssignment(t, db)
 
@@ -186,7 +186,7 @@ func TestGormDBUpdateSubmission(t *testing.T) {
 }
 
 func TestGormDBGetNonExistingSubmissions(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 	if _, err := db.GetLastSubmissions(10, &pb.Submission{UserID: 10}); err != gorm.ErrRecordNotFound {
 		t.Errorf("have error '%v' wanted '%v'", err, gorm.ErrRecordNotFound)
@@ -194,7 +194,7 @@ func TestGormDBGetNonExistingSubmissions(t *testing.T) {
 }
 
 func TestGormDBInsertSubmissions(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	// expected to fail with record not found
@@ -245,7 +245,7 @@ func TestGormDBInsertSubmissions(t *testing.T) {
 }
 
 func TestGormDBGetInsertSubmissions(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)

--- a/database/gormdb_test.go
+++ b/database/gormdb_test.go
@@ -8,7 +8,7 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestGormDBGetUser(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if _, err := db.GetUser(10); err != gorm.ErrRecordNotFound {
@@ -25,7 +25,7 @@ func TestGormDBGetUser(t *testing.T) {
 }
 
 func TestGormDBGetUsers(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if _, err := db.GetUsers(); err != nil {
@@ -34,7 +34,7 @@ func TestGormDBGetUsers(t *testing.T) {
 }
 
 func TestGormDBGetUserWithEnrollments(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 11)
@@ -133,7 +133,7 @@ func TestGormDBUpdateUser(t *testing.T) {
 		}
 	)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	var user pb.User
@@ -178,7 +178,7 @@ func TestGormDBUpdateUser(t *testing.T) {
 }
 
 func TestGormDBGetCourses(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	user := createFakeUser(t, db, 10)
@@ -240,7 +240,7 @@ func TestGormDBCreateEnrollmentNoRecord(t *testing.T) {
 		courseId = 1
 	)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -252,7 +252,7 @@ func TestGormDBCreateEnrollmentNoRecord(t *testing.T) {
 }
 
 func TestGormDBCreateEnrollment(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 1)
@@ -278,7 +278,7 @@ func TestGormDBCreateEnrollment(t *testing.T) {
 }
 
 func TestGormDBAcceptRejectEnrollment(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 1)
@@ -344,7 +344,7 @@ func TestGormDBAcceptRejectEnrollment(t *testing.T) {
 }
 
 func TestGormDBGetCoursesByUser(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 1)
@@ -416,7 +416,7 @@ func TestGormDBGetCoursesByUser(t *testing.T) {
 }
 
 func TestGormDBDuplicateIdentity(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if err := db.CreateUserFromRemoteIdentity(
@@ -482,7 +482,7 @@ func TestGormDBAssociateUserWithRemoteIdentity(t *testing.T) {
 		}
 	)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	// Create first user (the admin).
@@ -540,7 +540,7 @@ func TestGormDBAssociateUserWithRemoteIdentity(t *testing.T) {
 func TestGormDBSetAdminNoRecord(t *testing.T) {
 	const id = 1
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if err := db.UpdateUser(&pb.User{ID: id, IsAdmin: true}); err != gorm.ErrRecordNotFound {
@@ -554,7 +554,7 @@ func TestGormDBSetAdmin(t *testing.T) {
 		gitlab = "gitlab"
 	)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	// Create first user (the admin).
@@ -596,7 +596,7 @@ func TestGormDBSetAdmin(t *testing.T) {
 }
 
 func TestGormDBCreateCourse(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := pb.Course{
@@ -657,7 +657,7 @@ func TestGormDBCreateCourse(t *testing.T) {
 }
 
 func TestGormDBCreateCourseNonAdmin(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 10)
@@ -681,7 +681,7 @@ func TestGormDBGetCourse(t *testing.T) {
 		OrganizationID: 1234,
 	}
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	user := createFakeUser(t, db, 10)
@@ -710,7 +710,7 @@ func TestGormDBGetCourseByOrganization(t *testing.T) {
 		OrganizationID: 1234,
 	}
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	user := createFakeUser(t, db, 10)
@@ -730,7 +730,7 @@ func TestGormDBGetCourseByOrganization(t *testing.T) {
 }
 
 func TestGormDBGetCourseNoRecord(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if _, err := db.GetCourse(10, false); err != gorm.ErrRecordNotFound {
@@ -756,7 +756,7 @@ func TestGormDBUpdateCourse(t *testing.T) {
 		OrganizationID: 12345,
 	}
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 10)
@@ -781,7 +781,7 @@ func TestGormDBUpdateCourse(t *testing.T) {
 }
 
 func TestGormDBGetEmptyRepo(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 	if _, err := db.GetRepositoryByRemoteID(10); err != gorm.ErrRecordNotFound {
 		t.Fatal(err)
@@ -804,7 +804,7 @@ func createFakeUser(t *testing.T, db database.Database, remoteID uint64) *pb.Use
 }
 
 func TestGormDBGetSingleRepoWithUser(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	user := createFakeUser(t, db, 10)
@@ -823,7 +823,7 @@ func TestGormDBGetSingleRepoWithUser(t *testing.T) {
 }
 
 func TestGormDBCreateSingleRepoWithMissingUser(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	repo := pb.Repository{
@@ -837,7 +837,7 @@ func TestGormDBCreateSingleRepoWithMissingUser(t *testing.T) {
 }
 
 func TestGormDBGetCourseRepoType(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	repo := pb.Repository{
@@ -859,7 +859,7 @@ func TestGormDBGetCourseRepoType(t *testing.T) {
 }
 
 func TestGormDBGetGroupSubmissions(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if sub, err := db.GetLastSubmissions(10, &pb.Submission{GroupID: 10}); err != gorm.ErrRecordNotFound {
@@ -869,7 +869,7 @@ func TestGormDBGetGroupSubmissions(t *testing.T) {
 }
 
 func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)
@@ -1021,7 +1021,7 @@ func TestGormDBGetInsertGroupSubmissions(t *testing.T) {
 }
 
 func TestGetRepositoriesByOrganization(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{
@@ -1084,7 +1084,7 @@ func TestGetRepositoriesByOrganization(t *testing.T) {
 }
 
 func TestDeleteGroup(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	teacher := createFakeUser(t, db, 10)
@@ -1147,7 +1147,7 @@ func TestDeleteGroup(t *testing.T) {
 }
 
 func TestGetRepositoriesByCourseIdAndType(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{
@@ -1208,7 +1208,7 @@ func TestGetRepositoriesByCourseIdAndType(t *testing.T) {
 }
 
 func TestGetRepoByCourseIdUserIdAndType(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{
@@ -1295,7 +1295,7 @@ func TestGetRepoByCourseIdUserIdAndType(t *testing.T) {
 }
 
 func TestGetRepositoryByCourseUser(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := &pb.Course{

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
 	"github.com/autograde/quickfeed/log"
 )
@@ -34,4 +35,21 @@ func TestDB(t *testing.T) (database.Database, func()) {
 			t.Error(err)
 		}
 	}
+}
+
+// CreateFakeUser is a test helper to create a user in the database
+// with the given remote id and the fake scm provider.
+func CreateFakeUser(t *testing.T, db database.Database, remoteID uint64) *pb.User {
+	t.Helper()
+	var user pb.User
+	err := db.CreateUserFromRemoteIdentity(&user,
+		&pb.RemoteIdentity{
+			Provider:    "fake",
+			RemoteID:    remoteID,
+			AccessToken: "token",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &user
 }

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -53,3 +53,32 @@ func CreateFakeUser(t *testing.T, db database.Database, remoteID uint64) *pb.Use
 	}
 	return &user
 }
+
+func CreateNamedUser(t *testing.T, db database.Database, remoteID uint64, name string) *pb.User {
+	t.Helper()
+	user := &pb.User{Name: name}
+	err := db.CreateUserFromRemoteIdentity(user,
+		&pb.RemoteIdentity{
+			Provider:    "fake",
+			RemoteID:    remoteID,
+			AccessToken: "token",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return user
+}
+
+func EnrollStudent(t *testing.T, db database.Database, student *pb.User, course *pb.Course) {
+	t.Helper()
+	if err := db.CreateEnrollment(&pb.Enrollment{UserID: student.ID, CourseID: course.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.UpdateEnrollment(&pb.Enrollment{
+		UserID:   student.ID,
+		CourseID: course.ID,
+		Status:   pb.Enrollment_STUDENT,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -8,6 +8,9 @@ import (
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/database"
 	"github.com/autograde/quickfeed/log"
+	"github.com/autograde/quickfeed/scm"
+	"github.com/autograde/quickfeed/web/auth"
+	"go.uber.org/zap"
 )
 
 // TestDB returns a test database and close function.
@@ -81,4 +84,15 @@ func EnrollStudent(t *testing.T, db database.Database, student *pb.User, course 
 	}); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// FakeProviderMap is a test helper function to create an SCM map.
+func FakeProviderMap(t *testing.T) (scm.SCM, *auth.Scms) {
+	t.Helper()
+	scms := auth.NewScms()
+	scm, err := scms.GetOrCreateSCMEntry(zap.NewNop(), "fake", "token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return scm, scms
 }

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -1,6 +1,9 @@
 package qtest
 
 import (
+	"crypto/rand"
+	"crypto/sha1"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -95,4 +98,13 @@ func FakeProviderMap(t *testing.T) (scm.SCM, *auth.Scms) {
 		t.Fatal(err)
 	}
 	return scm, scms
+}
+
+func RandomString(t *testing.T) string {
+	t.Helper()
+	randomness := make([]byte, 10)
+	if _, err := rand.Read(randomness); err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf("%x", sha1.Sum(randomness))[:6]
 }

--- a/internal/qtest/test_helper.go
+++ b/internal/qtest/test_helper.go
@@ -1,4 +1,4 @@
-package internal
+package qtest
 
 import (
 	"io/ioutil"

--- a/web/auth/auth_test.go
+++ b/web/auth/auth_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/web/auth"
 	"github.com/gorilla/sessions"
 	"github.com/labstack/echo-contrib/session"
@@ -85,7 +85,7 @@ func TestOAuth2LoginRedirect(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	authHandler := auth.OAuth2Login(zap.NewNop(), db)
@@ -107,7 +107,7 @@ func TestOAuth2CallbackBadRequest(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	authHandler := auth.OAuth2Callback(zap.NewNop(), db)
@@ -162,7 +162,7 @@ func testPreAuthLoggedIn(t *testing.T, haveSession, existingUser bool, newProvid
 		}
 	}
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if existingUser {
@@ -230,7 +230,7 @@ func TestOAuth2LoginAuthenticated(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	authHandler := auth.OAuth2Login(zap.NewNop(), db)
@@ -293,7 +293,7 @@ func testOAuth2Callback(t *testing.T, existingUser, haveSession bool) {
 		}
 	}
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	if existingUser {
@@ -337,7 +337,7 @@ func TestAccessControl(t *testing.T) {
 	e := echo.New()
 	c := e.NewContext(r, w)
 
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	// Create a new user.

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/markbates/goth"
@@ -62,7 +62,7 @@ var allCourses = []*pb.Course{
 }
 
 func TestGetCourses(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 10)
@@ -120,7 +120,7 @@ func fakeGothProvider() {
 }
 
 func TestNewCourse(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	// set up fake goth provider (only needs to be done once)
@@ -158,7 +158,7 @@ func TestNewCourse(t *testing.T) {
 }
 
 func TestNewCourseExistingRepos(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 10)
@@ -185,7 +185,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 }
 
 func TestEnrollmentProcess(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -288,7 +288,7 @@ func TestEnrollmentProcess(t *testing.T) {
 }
 
 func TestListCoursesWithEnrollment(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -358,7 +358,7 @@ func TestListCoursesWithEnrollment(t *testing.T) {
 }
 
 func TestListCoursesWithEnrollmentStatuses(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -424,7 +424,7 @@ func TestListCoursesWithEnrollmentStatuses(t *testing.T) {
 }
 
 func TestGetCourse(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -447,7 +447,7 @@ func TestGetCourse(t *testing.T) {
 }
 
 func TestPromoteDemoteRejectTeacher(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	fakeGothProvider()

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -66,7 +66,7 @@ func TestGetCourses(t *testing.T) {
 	defer cleanup()
 
 	admin := qtest.CreateFakeUser(t, db, 10)
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	var testCourses []*pb.Course
@@ -98,17 +98,6 @@ func withUserContext(ctx context.Context, user *pb.User) context.Context {
 	return metadata.NewIncomingContext(ctx, meta)
 }
 
-// fakeProviderMap is a test helper function to create an SCM map.
-func fakeProviderMap(t *testing.T) (scm.SCM, *auth.Scms) {
-	t.Helper()
-	scms := auth.NewScms()
-	scm, err := scms.GetOrCreateSCMEntry(zap.NewNop(), "fake", "token")
-	if err != nil {
-		t.Fatal(err)
-	}
-	return scm, scms
-}
-
 func fakeGothProvider() {
 	baseURL := "fake"
 	goth.UseProviders(&auth.FakeProvider{
@@ -127,7 +116,7 @@ func TestNewCourse(t *testing.T) {
 	fakeGothProvider()
 	admin := qtest.CreateFakeUser(t, db, 10)
 	ctx := withUserContext(context.Background(), admin)
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	for _, testCourse := range allCourses {
@@ -163,7 +152,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 
 	admin := qtest.CreateFakeUser(t, db, 10)
 	ctx := withUserContext(context.Background(), admin)
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	directory, _ := fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{Path: "path", Name: "name"})
@@ -190,7 +179,7 @@ func TestEnrollmentProcess(t *testing.T) {
 
 	admin := qtest.CreateFakeUser(t, db, 1)
 	ctx := withUserContext(context.Background(), admin)
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	_, err := fakeProvider.CreateOrganization(ctx, &scm.OrganizationOptions{Path: "path", Name: "name"})
 	if err != nil {
@@ -293,7 +282,7 @@ func TestListCoursesWithEnrollment(t *testing.T) {
 
 	admin := qtest.CreateFakeUser(t, db, 1)
 	user := qtest.CreateFakeUser(t, db, 2)
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	var testCourses []*pb.Course
@@ -372,7 +361,7 @@ func TestListCoursesWithEnrollmentStatuses(t *testing.T) {
 	}
 
 	user := qtest.CreateFakeUser(t, db, 2)
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -433,7 +422,7 @@ func TestGetCourse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	foundCourse, err := ags.GetCourse(context.Background(), &pb.CourseRequest{CourseID: course.ID})
@@ -463,7 +452,7 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	if err := db.CreateEnrollment(&pb.Enrollment{

--- a/web/courses_test.go
+++ b/web/courses_test.go
@@ -65,7 +65,7 @@ func TestGetCourses(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 10)
+	admin := qtest.CreateFakeUser(t, db, 10)
 	_, scms := fakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
@@ -125,7 +125,7 @@ func TestNewCourse(t *testing.T) {
 
 	// set up fake goth provider (only needs to be done once)
 	fakeGothProvider()
-	admin := createFakeUser(t, db, 10)
+	admin := qtest.CreateFakeUser(t, db, 10)
 	ctx := withUserContext(context.Background(), admin)
 	fakeProvider, scms := fakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
@@ -161,7 +161,7 @@ func TestNewCourseExistingRepos(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 10)
+	admin := qtest.CreateFakeUser(t, db, 10)
 	ctx := withUserContext(context.Background(), admin)
 	fakeProvider, scms := fakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
@@ -188,7 +188,7 @@ func TestEnrollmentProcess(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	ctx := withUserContext(context.Background(), admin)
 	fakeProvider, scms := fakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
@@ -202,7 +202,7 @@ func TestEnrollmentProcess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stud1 := createFakeUser(t, db, 2)
+	stud1 := qtest.CreateFakeUser(t, db, 2)
 	enrollStud1 := &pb.Enrollment{CourseID: course.ID, UserID: stud1.ID}
 	if _, err = ags.CreateEnrollment(ctx, enrollStud1); err != nil {
 		t.Fatal(err)
@@ -246,7 +246,7 @@ func TestEnrollmentProcess(t *testing.T) {
 
 	// create another user and enroll as student
 
-	stud2 := createFakeUser(t, db, 3)
+	stud2 := qtest.CreateFakeUser(t, db, 3)
 	enrollStud2 := &pb.Enrollment{CourseID: course.ID, UserID: stud2.ID}
 	if _, err = ags.CreateEnrollment(ctx, enrollStud2); err != nil {
 		t.Fatal(err)
@@ -291,8 +291,8 @@ func TestListCoursesWithEnrollment(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
-	user := createFakeUser(t, db, 2)
+	admin := qtest.CreateFakeUser(t, db, 1)
+	user := qtest.CreateFakeUser(t, db, 2)
 	_, scms := fakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
@@ -361,7 +361,7 @@ func TestListCoursesWithEnrollmentStatuses(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	var testCourses []*pb.Course
 	for _, course := range allCourses {
 		err := db.CreateCourse(admin.ID, course)
@@ -371,7 +371,7 @@ func TestListCoursesWithEnrollmentStatuses(t *testing.T) {
 		testCourses = append(testCourses, course)
 	}
 
-	user := createFakeUser(t, db, 2)
+	user := qtest.CreateFakeUser(t, db, 2)
 	_, scms := fakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
@@ -427,7 +427,7 @@ func TestGetCourse(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	course := allCourses[0]
 	err := db.CreateCourse(admin.ID, course)
 	if err != nil {
@@ -452,10 +452,10 @@ func TestPromoteDemoteRejectTeacher(t *testing.T) {
 
 	fakeGothProvider()
 
-	teacher := createFakeUser(t, db, 10)
-	student1 := createFakeUser(t, db, 11)
-	student2 := createFakeUser(t, db, 12)
-	ta := createFakeUser(t, db, 13)
+	teacher := qtest.CreateFakeUser(t, db, 10)
+	student1 := qtest.CreateFakeUser(t, db, 11)
+	student2 := qtest.CreateFakeUser(t, db, 12)
+	ta := qtest.CreateFakeUser(t, db, 13)
 
 	course := allCourses[0]
 	err := db.CreateCourse(teacher.ID, course)

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -40,7 +40,7 @@ func TestNewGroup(t *testing.T) {
 	}
 
 	ctx := withUserContext(context.Background(), admin)
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	_, err := fakeProvider.CreateOrganization(ctx,
@@ -95,7 +95,7 @@ func TestCreateGroupWithMissingFields(t *testing.T) {
 	}
 
 	ctx := withUserContext(context.Background(), admin)
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	_, err := fakeProvider.CreateOrganization(ctx,
@@ -164,7 +164,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	_, err := fakeProvider.CreateOrganization(context.Background(),
@@ -247,7 +247,7 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ctx := withUserContext(context.Background(), user)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
@@ -277,7 +277,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 
 	// set up fake goth provider (only needs to be done once)
 	fakeGothProvider()
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	_, err := fakeProvider.CreateOrganization(context.Background(),
 		&scm.OrganizationOptions{Path: "path", Name: "name"},
@@ -503,7 +503,7 @@ func TestDeleteGroup(t *testing.T) {
 
 	group := &pb.Group{Name: "Test Delete Group", CourseID: testCourse.ID, Users: []*pb.User{user}}
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	ctx := withUserContext(context.Background(), user)
@@ -549,7 +549,7 @@ func TestGetGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), user)
 
@@ -603,7 +603,7 @@ func TestPatchGroupStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), teacher)
 
@@ -696,7 +696,7 @@ func TestGetGroupByUserAndCourse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 
@@ -765,7 +765,7 @@ func TestDeleteApprovedGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 
@@ -882,7 +882,7 @@ func TestGetGroups(t *testing.T) {
 	}
 	admin := users[0]
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	// admin will be enrolled as teacher because of course creation below
 	withUserContext(context.Background(), admin)

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -19,7 +19,7 @@ func TestNewGroup(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	var course pb.Course
 	course.Provider = "fake"
 	// only created 1 directory, if we had created two directories ID would be 2
@@ -27,7 +27,7 @@ func TestNewGroup(t *testing.T) {
 	if err := db.CreateCourse(admin.ID, &course); err != nil {
 		t.Fatal(err)
 	}
-	user := createFakeUser(t, db, 2)
+	user := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestCreateGroupWithMissingFields(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	var course pb.Course
 	course.Provider = "fake"
 	// only created 1 directory, if we had created two directories ID would be 2
@@ -82,7 +82,7 @@ func TestCreateGroupWithMissingFields(t *testing.T) {
 	if err := db.CreateCourse(admin.ID, &course); err != nil {
 		t.Fatal(err)
 	}
-	user := createFakeUser(t, db, 2)
+	user := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	var course pb.Course
 	course.Provider = "fake"
 	// only created 1 directory, if we had created two directories ID would be 2
@@ -140,7 +140,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	teacher := createFakeUser(t, db, 2)
+	teacher := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: teacher.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user := createFakeUser(t, db, 3)
+	user := qtest.CreateFakeUser(t, db, 3)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +214,7 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	var course pb.Course
 	course.Provider = "fake"
 	// only created 1 directory, if we had created two directories ID would be 2
@@ -223,7 +223,7 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	teacher := createFakeUser(t, db, 2)
+	teacher := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: teacher.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user := createFakeUser(t, db, 3)
+	user := qtest.CreateFakeUser(t, db, 3)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -286,13 +286,13 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	course := pb.Course{Provider: "fake", OrganizationID: 1}
 	if err := db.CreateCourse(admin.ID, &course); err != nil {
 		t.Fatal(err)
 	}
 
-	teacher := createFakeUser(t, db, 2)
+	teacher := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: teacher.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +304,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user1 := createFakeUser(t, db, 3)
+	user1 := qtest.CreateFakeUser(t, db, 3)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user1.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	user2 := createFakeUser(t, db, 4)
+	user2 := qtest.CreateFakeUser(t, db, 4)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user2.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -326,7 +326,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	user3 := createFakeUser(t, db, 5)
+	user3 := qtest.CreateFakeUser(t, db, 5)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user3.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -471,13 +471,13 @@ func TestDeleteGroup(t *testing.T) {
 		OrganizationID: 1,
 		ID:             1,
 	}
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	if err := db.CreateCourse(admin.ID, &testCourse); err != nil {
 		t.Fatal(err)
 	}
 
 	// create user and enroll as student
-	user := createFakeUser(t, db, 2)
+	user := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user.ID, CourseID: testCourse.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -489,7 +489,7 @@ func TestDeleteGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 	// create teacher and enroll as teacher
-	teacher := createFakeUser(t, db, 3)
+	teacher := qtest.CreateFakeUser(t, db, 3)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: teacher.ID, CourseID: testCourse.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -531,13 +531,13 @@ func TestGetGroup(t *testing.T) {
 		Provider:       "fake",
 		OrganizationID: 1,
 	}
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	if err := db.CreateCourse(admin.ID, &testCourse); err != nil {
 		t.Fatal(err)
 	}
 
 	// create user and enroll as student
-	user := createFakeUser(t, db, 2)
+	user := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: user.ID, CourseID: testCourse.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -582,13 +582,13 @@ func TestPatchGroupStatus(t *testing.T) {
 		ID:             1,
 	}
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	err := db.CreateCourse(admin.ID, &course)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	teacher := createFakeUser(t, db, 2)
+	teacher := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: teacher.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -614,8 +614,8 @@ func TestPatchGroupStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user1 := createFakeUser(t, db, 3)
-	user2 := createFakeUser(t, db, 4)
+	user1 := qtest.CreateFakeUser(t, db, 3)
+	user2 := qtest.CreateFakeUser(t, db, 4)
 
 	// enroll users in course and group
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -690,7 +690,7 @@ func TestGetGroupByUserAndCourse(t *testing.T) {
 		ID:             1,
 	}
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	err := db.CreateCourse(admin.ID, &course)
 	if err != nil {
 		t.Fatal(err)
@@ -700,8 +700,8 @@ func TestGetGroupByUserAndCourse(t *testing.T) {
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 
-	user1 := createFakeUser(t, db, 2)
-	user2 := createFakeUser(t, db, 3)
+	user1 := qtest.CreateFakeUser(t, db, 2)
+	user2 := qtest.CreateFakeUser(t, db, 3)
 
 	// enroll users in course and group
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -758,7 +758,7 @@ func TestDeleteApprovedGroup(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 	course := allCourses[0]
 	err := db.CreateCourse(admin.ID, course)
 	if err != nil {
@@ -776,8 +776,8 @@ func TestDeleteApprovedGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user1 := createFakeUser(t, db, 2)
-	user2 := createFakeUser(t, db, 3)
+	user1 := qtest.CreateFakeUser(t, db, 2)
+	user2 := qtest.CreateFakeUser(t, db, 3)
 
 	// enroll users in course and group
 	if err := db.CreateEnrollment(&pb.Enrollment{
@@ -877,7 +877,7 @@ func TestGetGroups(t *testing.T) {
 
 	var users []*pb.User
 	for _, u := range allUsers {
-		user := createFakeUser(t, db, u.remoteID)
+		user := qtest.CreateFakeUser(t, db, u.remoteID)
 		users = append(users, user)
 	}
 	admin := users[0]

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -10,13 +10,13 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/scm"
 	"github.com/autograde/quickfeed/web"
 )
 
 func TestNewGroup(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -71,7 +71,7 @@ func TestNewGroup(t *testing.T) {
 }
 
 func TestCreateGroupWithMissingFields(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -128,7 +128,7 @@ func TestCreateGroupWithMissingFields(t *testing.T) {
 }
 
 func TestNewGroupTeacherCreator(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -211,7 +211,7 @@ func TestNewGroupTeacherCreator(t *testing.T) {
 }
 
 func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -272,7 +272,7 @@ func TestNewGroupStudentCreateGroupWithTeacher(t *testing.T) {
 }
 
 func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	// set up fake goth provider (only needs to be done once)
@@ -459,7 +459,7 @@ func TestStudentCreateNewGroupTeacherUpdateGroup(t *testing.T) {
 }
 
 func TestDeleteGroup(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	testCourse := pb.Course{
@@ -520,7 +520,7 @@ func TestDeleteGroup(t *testing.T) {
 }
 
 func TestGetGroup(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	testCourse := pb.Course{
@@ -569,7 +569,7 @@ func TestGetGroup(t *testing.T) {
 }
 
 func TestPatchGroupStatus(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := pb.Course{
@@ -677,7 +677,7 @@ func TestPatchGroupStatus(t *testing.T) {
 }
 
 func TestGetGroupByUserAndCourse(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	course := pb.Course{
@@ -755,7 +755,7 @@ func TestGetGroupByUserAndCourse(t *testing.T) {
 }
 
 func TestDeleteApprovedGroup(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -872,7 +872,7 @@ func TestDeleteApprovedGroup(t *testing.T) {
 }
 
 func TestGetGroups(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	var users []*pb.User

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -7,7 +7,7 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/kit/score"
 	"github.com/autograde/quickfeed/log"
 	"github.com/autograde/quickfeed/scm"
@@ -18,7 +18,7 @@ import (
 )
 
 func TestSubmissionsAccess(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -257,7 +257,7 @@ func TestSubmissionsAccess(t *testing.T) {
 }
 
 func TestApproveSubmission(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -346,7 +346,7 @@ func TestApproveSubmission(t *testing.T) {
 }
 
 func TestGetCourseLabSubmissions(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)
@@ -528,7 +528,7 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 }
 
 func TestCreateApproveList(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	admin := createFakeUser(t, db, 1)

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -21,9 +21,9 @@ func TestSubmissionsAccess(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 
-	teacher := createFakeUser(t, db, 2)
+	teacher := qtest.CreateFakeUser(t, db, 2)
 	err := db.UpdateUser(&pb.User{ID: teacher.ID, IsAdmin: true})
 	if err != nil {
 		t.Fatal(err)
@@ -37,7 +37,7 @@ func TestSubmissionsAccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	student1 := createFakeUser(t, db, 3)
+	student1 := qtest.CreateFakeUser(t, db, 3)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: student1.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestSubmissionsAccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	student2 := createFakeUser(t, db, 4)
+	student2 := qtest.CreateFakeUser(t, db, 4)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: student2.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestSubmissionsAccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	student3 := createFakeUser(t, db, 5)
+	student3 := qtest.CreateFakeUser(t, db, 5)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: student3.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestApproveSubmission(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 
 	course := allCourses[0]
 	err := db.CreateCourse(admin.ID, course)
@@ -268,7 +268,7 @@ func TestApproveSubmission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	student := createFakeUser(t, db, 2)
+	student := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: student.ID, CourseID: course.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -349,7 +349,7 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 
 	course1 := allCourses[2]
 	course2 := allCourses[3]
@@ -360,7 +360,7 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	student := createFakeUser(t, db, 2)
+	student := qtest.CreateFakeUser(t, db, 2)
 	if err := db.CreateEnrollment(&pb.Enrollment{UserID: student.ID, CourseID: course1.ID}); err != nil {
 		t.Fatal(err)
 	}
@@ -531,7 +531,7 @@ func TestCreateApproveList(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	admin := createFakeUser(t, db, 1)
+	admin := qtest.CreateFakeUser(t, db, 1)
 
 	course := allCourses[2]
 	if err := db.CreateCourse(admin.ID, course); err != nil {

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -66,7 +66,7 @@ func TestSubmissionsAccess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), teacher)
 
@@ -299,7 +299,7 @@ func TestApproveSubmission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 
@@ -450,7 +450,7 @@ func TestGetCourseLabSubmissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(log.Zap(false), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 
@@ -638,7 +638,7 @@ func TestCreateApproveList(t *testing.T) {
 		}
 	}
 
-	fakeProvider, scms := fakeProviderMap(t)
+	fakeProvider, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 	_, err := fakeProvider.CreateOrganization(context.Background(), &scm.OrganizationOptions{Path: "path", Name: "name"})

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -537,12 +537,12 @@ func TestCreateApproveList(t *testing.T) {
 	if err := db.CreateCourse(admin.ID, course); err != nil {
 		t.Fatal(err)
 	}
-	student1 := createNamedUser(t, db, 2, "Leslie Lamport")
-	student2 := createNamedUser(t, db, 3, "Hein Meling")
-	student3 := createNamedUser(t, db, 4, "John Doe")
-	enrollStudent(t, db, student1, course)
-	enrollStudent(t, db, student2, course)
-	enrollStudent(t, db, student3, course)
+	student1 := qtest.CreateNamedUser(t, db, 2, "Leslie Lamport")
+	student2 := qtest.CreateNamedUser(t, db, 3, "Hein Meling")
+	student3 := qtest.CreateNamedUser(t, db, 4, "John Doe")
+	qtest.EnrollStudent(t, db, student1, course)
+	qtest.EnrollStudent(t, db, student2, course)
+	qtest.EnrollStudent(t, db, student3, course)
 
 	assignments := []*pb.Assignment{
 		{

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -34,7 +34,7 @@ func TestGetSelf(t *testing.T) {
 		bufSize = 1024 * 1024
 	)
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 
 	adminUser := qtest.CreateFakeUser(t, db, 1)
 	student := qtest.CreateFakeUser(t, db, 56)
@@ -127,7 +127,7 @@ func TestGetUsers(t *testing.T) {
 	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	unexpectedUsers, err := ags.GetUsers(context.Background(), &pb.Void{})
 	if err == nil && unexpectedUsers != nil && len(unexpectedUsers.GetUsers()) > 0 {
@@ -191,7 +191,7 @@ func TestGetEnrollmentsByCourse(t *testing.T) {
 		}
 	}
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 
@@ -271,7 +271,7 @@ func TestEnrollmentsWithoutGroupMembership(t *testing.T) {
 	}
 	admin := users[0]
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), admin)
 
@@ -354,7 +354,7 @@ func TestUpdateUser(t *testing.T) {
 	firstAdminUser := qtest.CreateFakeUser(t, db, 1)
 	nonAdminUser := qtest.CreateFakeUser(t, db, 11)
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 	ctx := withUserContext(context.Background(), firstAdminUser)
 
@@ -415,7 +415,7 @@ func TestUpdateUserFailures(t *testing.T) {
 	adminUser := qtest.CreateFakeUser(t, db, 1)
 	qtest.CreateFakeUser(t, db, 11)
 
-	_, scms := fakeProviderMap(t)
+	_, scms := qtest.FakeProviderMap(t)
 	ags := web.NewAutograderService(zap.NewNop(), db, scms, web.BaseHookOptions{}, &ci.Local{})
 
 	u := qtest.CreateFakeUser(t, db, 3)

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -10,7 +10,6 @@ import (
 
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
-	"github.com/autograde/quickfeed/database"
 	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/web"
 	"github.com/autograde/quickfeed/web/auth"
@@ -479,34 +478,5 @@ func TestUpdateUserFailures(t *testing.T) {
 
 	if !cmp.Equal(withName, wantUser, cmpopts.IgnoreUnexported(pb.User{}, pb.RemoteIdentity{})) {
 		t.Errorf("\nhave: %+v\nwant: %+v\n", withName, wantUser)
-	}
-}
-
-func createNamedUser(t *testing.T, db database.Database, remoteID uint64, name string) *pb.User {
-	t.Helper()
-	user := &pb.User{Name: name}
-	err := db.CreateUserFromRemoteIdentity(user,
-		&pb.RemoteIdentity{
-			Provider:    "fake",
-			RemoteID:    remoteID,
-			AccessToken: "token",
-		})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return user
-}
-
-func enrollStudent(t *testing.T, db database.Database, student *pb.User, course *pb.Course) {
-	t.Helper()
-	if err := db.CreateEnrollment(&pb.Enrollment{UserID: student.ID, CourseID: course.ID}); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.UpdateEnrollment(&pb.Enrollment{
-		UserID:   student.ID,
-		CourseID: course.ID,
-		Status:   pb.Enrollment_STUDENT,
-	}); err != nil {
-		t.Fatal(err)
 	}
 }

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -11,7 +11,7 @@ import (
 	pb "github.com/autograde/quickfeed/ag"
 	"github.com/autograde/quickfeed/ci"
 	"github.com/autograde/quickfeed/database"
-	"github.com/autograde/quickfeed/internal"
+	"github.com/autograde/quickfeed/internal/qtest"
 	"github.com/autograde/quickfeed/web"
 	"github.com/autograde/quickfeed/web/auth"
 	"github.com/google/go-cmp/cmp"
@@ -28,7 +28,7 @@ import (
 )
 
 func TestGetSelf(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	const (
@@ -125,7 +125,7 @@ func TestGetSelf(t *testing.T) {
 }
 
 func TestGetUsers(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	_, scms := fakeProviderMap(t)
@@ -174,7 +174,7 @@ var allUsers = []struct {
 }
 
 func TestGetEnrollmentsByCourse(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	var users []*pb.User
@@ -262,7 +262,7 @@ func TestGetEnrollmentsByCourse(t *testing.T) {
 }
 
 func TestEnrollmentsWithoutGroupMembership(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 
 	var users []*pb.User
@@ -350,7 +350,7 @@ func TestEnrollmentsWithoutGroupMembership(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 	firstAdminUser := createFakeUser(t, db, 1)
 	nonAdminUser := createFakeUser(t, db, 11)
@@ -410,7 +410,7 @@ func TestUpdateUser(t *testing.T) {
 }
 
 func TestUpdateUserFailures(t *testing.T) {
-	db, cleanup := internal.TestDB(t)
+	db, cleanup := qtest.TestDB(t)
 	defer cleanup()
 	// user := &pb.User{Name: "Test User", StudentID: "11", Email: "test@email", AvatarURL: "url.com"}
 	adminUser := createFakeUser(t, db, 1)


### PR DESCRIPTION
- Moved internal.TestDB to internal/qtest
- Replace createFakeUser with internal/qtest.CreateFakeUser()
- Added CreatedNamedUser and EnrollStudent test helpers
- Added qtest.FakeProviderMap test helper
- Added qtest.RandomString(t) test helper

Fixes #481.

