### PR TITLE
Remove fake provider command line flag and corresponding code

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,6 @@ func main() {
 		public   = flag.String("http.public", "public", "path to content to serve")
 		httpAddr = flag.String("http.addr", ":8081", "HTTP listen address")
 		grpcAddr = flag.String("grpc.addr", ":9090", "gRPC listen address")
-		fake     = flag.Bool("provider.fake", false, "enable fake provider")
 	)
 	flag.Parse()
 
@@ -91,7 +90,7 @@ func main() {
 	defer runner.Close()
 
 	agService := web.NewAutograderService(logger, db, scms, bh, runner)
-	go web.New(agService, *public, *httpAddr, *fake)
+	go web.New(agService, *public, *httpAddr)
 
 	lis, err := net.Listen("tcp", *grpcAddr)
 	if err != nil {

--- a/web/webserver.go
+++ b/web/webserver.go
@@ -29,7 +29,7 @@ var (
 )
 
 // New starts a new web server
-func New(ags *AutograderService, public, httpAddr string, fake bool) {
+func New(ags *AutograderService, public, httpAddr string) {
 	entryPoint := filepath.Join(public, "index.html")
 	if _, err := os.Stat(entryPoint); os.IsNotExist(err) {
 		ags.logger.Fatalf("file not found %s", entryPoint)
@@ -39,7 +39,7 @@ func New(ags *AutograderService, public, httpAddr string, fake bool) {
 	gothic.Store = store
 	e := newServer(ags, store)
 
-	enabled := enableProviders(ags.logger, ags.bh.BaseURL, fake)
+	enabled := enableProviders(ags.logger, ags.bh.BaseURL)
 	registerWebhooks(ags, e, enabled)
 	registerAuth(ags, e)
 
@@ -67,7 +67,7 @@ func newStore(keyPairs ...[]byte) sessions.Store {
 	return store
 }
 
-func enableProviders(l *zap.SugaredLogger, baseURL string, fake bool) map[string]bool {
+func enableProviders(l *zap.SugaredLogger, baseURL string) map[string]bool {
 	enabled := make(map[string]bool)
 
 	if ok := auth.EnableProvider(&auth.Provider{
@@ -98,16 +98,6 @@ func enableProviders(l *zap.SugaredLogger, baseURL string, fake bool) map[string
 		enabled["gitlab"] = true
 	} else {
 		l.Debug("environment variable not set for gitlab")
-	}
-
-	if fake {
-		l.Debug("fake provider enabled")
-		goth.UseProviders(&auth.FakeProvider{
-			Callback: auth.GetCallbackURL(baseURL, "fake"),
-		})
-		goth.UseProviders(&auth.FakeProvider{
-			Callback: auth.GetCallbackURL(baseURL, "fake-teacher"),
-		})
 	}
 
 	return enabled


### PR DESCRIPTION
This code hasn't been used since 2017 or so.

Fixes #386.

