### PR TITLE
Renamed Autograder to QuickFeed in doc (not code)

### DIFF
--- a/database/gormdb_repository.go
+++ b/database/gormdb_repository.go
@@ -27,7 +27,7 @@ func (db *GormDB) CreateRepository(repo *pb.Repository) error {
 			return err
 		}
 	case !repo.RepoType.IsCourseRepo():
-		// both user and group unset, then repository type must be an autograder repo type
+		// both user and group unset, then repository type must be an QuickFeed repo type
 		return ErrCreateRepo
 	}
 

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -168,7 +168,7 @@ When the client is supposed to show error message to the user, error from the se
 
 ### Backend
 
-Errors are being logged at `Autograder Service` level. All other methods called from there (including database and scm methods) will just wrap and return all error messages directly. Introduce logging on layers deeper than `Autograder Service` only if necessary.
+Errors are being logged at `QuickFeed Service` level. All other methods called from there (including database and scm methods) will just wrap and return all error messages directly. Introduce logging on layers deeper than `QuickFeed Service` only if necessary.
 
 Errors returned to user interface must be few and informative, yet should not provide too many information about server routines. User must only be informed about details he or she can do something about.
 

--- a/doc/templates/policy.md
+++ b/doc/templates/policy.md
@@ -4,7 +4,7 @@ All lab assignments must be completed to satisfaction (passed) in order to sit f
 
 ## Lab Approval Process
 
-Some of the assignments will be automatically approved by Autograder when sufficiently many tests pass; these does not require any manual approval.
+Some of the assignments will be automatically approved by QuickFeed when sufficiently many tests pass; these does not require any manual approval.
 
 For assignments that require manual approval, *you must* present your solution to a member of the teaching staff.
 This should be done during lab hours, and can be done remotely via Discord.
@@ -14,8 +14,8 @@ When you are ready to show your solution, follow the instructions on Discord to 
 Do not send messages directly to the teaching staff on Discord.
 
 It is expected that you can explain your code and show how it works.
-The results from Autograder will also be taken into consideration when approving a lab.
-At least 90% of the Autograder tests should pass for the lab to be approved.
+The results from QuickFeed will also be taken into consideration when approving a lab.
+At least 90% of the QuickFeed tests should pass for the lab to be approved.
 
 Note that, while we prefer that you get approval for each lab on time, it is ok to make arrangements to get approval at a later date, as long as the handin is submitted to GitHub on time.
 Please contact the teaching staff to make arrangements.
@@ -44,7 +44,7 @@ You may discuss the assignments with others, but you may not copy answers or cod
 
 ### Group Assignments
 
-For group assignments we expect students to form groups on Autograder and work together.
+For group assignments we expect students to form groups on QuickFeed and work together.
 Group members must contribute equally to code, written handins, and oral presentations, e.g. for approval.
 
 Groups cannot be composed of members whose commitment to contribute to the group work is disproportionately different.

--- a/kit/src/main/java/autograder/Score.java
+++ b/kit/src/main/java/autograder/Score.java
@@ -7,7 +7,7 @@ package main.java.autograder;
 //Secret read from the output steam need to correspond to the course identifier
 //given on the teachers panel. All other output will be ignored.
 //
-//With the formula in the Autograder CI the score percentage is calculated
+//With the formula in the QuickFeed CI the score percentage is calculated
 //automatically. Give any max score, then pass on a given score the student
 //gets for passed sub test within this the max score. Finally, set a weight
 //it should have on the total. The weight does not need to within 100 or a
@@ -26,7 +26,7 @@ public class Score {
 	private int MaxScore;
 	private int Weight;
 	
-	// GolbalSecret represents the unique course identifier that will be used in
+	// GlobalSecret represents the unique course identifier that will be used in
 	// the Score struct constructors. Users of this package should set this
 	// variable appropriately before using any exported
 	// function in this package.

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Autograder</title>
+    <title>QuickFeed</title>
     <!-- Disable React Dev Tools in production -->
     <script>
         if (window.location.hostname === "uis.itest.run" && typeof window.__REACT_DEVTOOLS_GLOBAL_HOOK__ === 'object') {

--- a/public/package.json
+++ b/public/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reactcomponents",
   "version": "0.1.0",
-  "description": "React Components for the Autograder Project",
+  "description": "React Components for the QuickFeed Project",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/public/src/components/forms/CourseForm.tsx
+++ b/public/src/components/forms/CourseForm.tsx
@@ -113,14 +113,14 @@ export class CourseForm<T> extends React.Component<ICourseFormProps, ICourseForm
     private renderInfo(): JSX.Element {
         const gitMsg: JSX.Element =
             <div>
-                <p>For each new semester of a course, Autograder requires a new GitHub organization.
+                <p>For each new semester of a course, QuickFeed requires a new GitHub organization.
             This is to keep the student roster for the different runs of the course separate.</p>
 
                 <p><a href="https://github.com/account/organizations/new"
                     target="_blank">Create an organization for your course</a>.
                   The course organization must allow private repositories. </p>
 
-                <p>Autograder will create a following repositories for you:</p>
+                <p>QuickFeed will create a following repositories for you:</p>
 
                 <div>
                     <ul>

--- a/public/src/index.tsx
+++ b/public/src/index.tsx
@@ -262,7 +262,7 @@ class AutoGrader extends React.Component<IAutoGraderProps, IAutoGraderState> {
                     isFluid={false}
                     isInverse={true}
                     onClick={(link) => this.handleClick(link)}
-                    brandName="Autograder">
+                    brandName="QuickFeed">
                     <NavBarMenu links={this.state.topLinks}
                         onClick={(link) => this.handleClick(link)}>
                     </NavBarMenu>

--- a/public/src/pages/HomePage.tsx
+++ b/public/src/pages/HomePage.tsx
@@ -57,7 +57,7 @@ export class HomePage extends ViewPage {
                         On due date of an assignment, the most recent version
                         of each student's code is available through GitHub.
                         Easily accessible for the teachers.
-                        Together with latest build log, this makes grading easier and more fair.
+                        Together with latest build log, this makes grading easier and fair.
                     </p>
                     <p>
                         <a className="btn btn-default" href="#grading" role="button">View details »</a>
@@ -69,17 +69,17 @@ export class HomePage extends ViewPage {
                 <div key="row1" className="row featurette">
                     <div key="c1r1" className="col-md-7">
                         <h2 className="featurette-heading">
-                            Autograder: <span className="text-muted">Automated student feedback</span>
+                            QuickFeed: <span className="text-muted">Instant Feedback on Programming Assignments</span>
                         </h2>
                         <p className="lead">
-                            Autograder aims to provide students with fast
+                            QuickFeed aims to provide students with instant
                             feedback on their lab assignments, and is designed
                             to help students learn about state-of-the-art tools
                             used in the industry.
-                            Autograder builds upon version control systems and
+                            QuickFeed builds upon version control systems and
                             continuous integration.
                             When students upload code to their repositories,
-                            Autograder automatically builds their code and
+                            QuickFeed automatically builds their code and
                             provides feedback based on tests supplied by the
                             teaching staff.
                             When grading assignments, teaching staff can access
@@ -113,8 +113,8 @@ export class HomePage extends ViewPage {
                         <p className="lead">
                             A course is an organization on GitHub.
                             Students get access to their own private GitHub repository.
-                            Uploading their code for review or grading, students can
-                             learn to use git for version control.
+                            Uploading their code for review or grading, students will
+                            learn to use git for version control.
                         </p>
                     </div>
                 </div>
@@ -126,10 +126,10 @@ export class HomePage extends ViewPage {
                 <div key="row3" className="row featurette">
                     <div key="c1r3" className="col-md-7">
                         <h2 className="featurette-heading">
-                            Continuous Integration: <span className="text-muted">builds and tests student code. </span>
+                            Continuous Integration: <span className="text-muted">builds and tests student code.</span>
                         </h2>
                         <p className="lead">
-                            As code gets pushed up to GitHub, an automatic build process
+                            As code gets pushed to GitHub, an automatic build process
                             defined by the teacher, generates feedback to students.
                             When the build process is completed, student gets immediate
                             access to this feedback on their personal course page.
@@ -183,11 +183,10 @@ export class HomePage extends ViewPage {
                 <div key="cblock" className="centerblock container">
                     <h1>Automated student feedback</h1>
                     <p>
-                        <strong>Autograder </strong>
-                        provides instantaneous feedback to students on
+                        <strong>QuickFeed</strong>
+                        provides rapid feedback to students on
                         their programming assignments. It is also a
-                        valuable tool for teachers when grading lab
-                        assignments.
+                        valuable tool for teachers when grading lab assignments.
                     </p>
                     <p>
                         <a className="btn btn-primary btn-lg" href="#autograder" role="button">Learn more »</a>

--- a/public/src/pages/views/HelpView.tsx
+++ b/public/src/pages/views/HelpView.tsx
@@ -8,7 +8,7 @@ export class HelpView extends React.Component<{}, {}> {
                 <div className="col-md-2 col-sm-3 col-xs-12">
                     <div className="list-group">
                         <a href="#" className="list-group-item disabled">Help</a>
-                        <a href="#autograder" className="list-group-item">Autograder</a>
+                        <a href="#autograder" className="list-group-item">QuickFeed</a>
                         <a href="#reg" className="list-group-item">Registration</a>
                         <a href="#signup" className="list-group-item">Sign up for a course</a>
                         <a href="#groups" className="list-group-item">Creating a group</a>
@@ -17,9 +17,9 @@ export class HelpView extends React.Component<{}, {}> {
                 </div>
                 <div className="col-md-8 col-sm-9 col-xs-12">
                     <article>
-                        <h1 id="autograder">Autograder</h1>
+                        <h1 id="autograder">QuickFeed</h1>
                         <p>
-                            Autograder is a tool for students and teaching staff for
+                            QuickFeed is a tool for students and teaching staff for
                             submitting and validating lab assignments and is developed at
                             the University of Stavanger. All lab submissions from students
                             are handled using Git, a source code management system, and
@@ -27,27 +27,27 @@ export class HelpView extends React.Component<{}, {}> {
                         </p>
                         <p>
                             Students push their lab solutions to GitHub. Every
-                             submission is then processed by a custom continuous
+                            submission is then processed by a custom continuous
                             integration tool. This tool will run several test cases on the
-                            submitted code. Autograder generates feedback that lets the
+                            submitted code. QuickFeed generates feedback that lets the
                             students verify that their submission implements the required
                             functionality. This feedback is available through a web interface.
-                            The feedback from the Autograder system can be used by students
+                            The feedback from the QuickFeed system can be used by students
                             to improve their submissions.
                         </p>
                         <p>
                             Below is a step-by-step explanation on how to register and sign up
-                            for the lab project in Autograder.
+                            for the lab project in QuickFeed.
                         </p>
 
                         <h1 id="reg">Registration</h1>
-
                         <ol>
                             <li>
                                 <p>
                                     Go to <a href="http://github.com">GitHub</a> and register.
-                                    A GitHub account is required to sign in to Autograder.
-                                    You can skip this step if you already have an account.</p>
+                                    A GitHub account is required to sign in to QuickFeed.
+                                    You can skip this step if you already have an account.
+                                </p>
                             </li>
                             <li>
                                 <p>
@@ -57,27 +57,25 @@ export class HelpView extends React.Component<{}, {}> {
                             </li>
                             <li>
                                 <p>
-                                    Approve that the Autograder application may access the
+                                    Approve that the QuickFeed application may access the
                                     requested parts of your account. It is possible to make a
-                                     separate GitHub account for Autograder if you do not
-                                      want the application to access your personal one with
+                                    separate GitHub account for QuickFeed if you do not
+                                    want the application to access your personal one with
                                     the requested permissions.
-                                    </p>
+                                </p>
                             </li>
                             <li>
                                 <p>
                                     Fill in your information and register as a new user.
-                                     Please provide your real name in the "Name" field.
-                                     This name will be used to approve your submissions
-                                     to course assignments during the lab hours.
+                                    Please provide your real name in the "Name" field.
+                                    This name will be used to approve your submissions
+                                    to course assignments during the lab hours.
                                 </p>
                             </li>
                         </ol>
 
                         <h1 id="signup">Signing up for a course</h1>
-
                         <ol>
-
                             <li>
                                 <p>Click the course menu item.</p>
                             </li>
@@ -91,31 +89,27 @@ export class HelpView extends React.Component<{}, {}> {
                             </li>
                             <li>
                                 <p>
-                                 Wait for the teaching staff to accept your enrollment request.
+                                    Wait for the teaching staff to accept your enrollment request.
                                 </p>
                             </li>
                             <li>
                                 <p>
                                     After your enrollment request has been accepted,
-                                     you will receive three GitHub invitations. Invitations will be sent
-                                     to the email associated with the GitHub account you've signed up
-                                      for the course with.
+                                    you will receive three GitHub invitations. Invitations will be sent
+                                    to the email associated with the GitHub account you've signed up
+                                    for the course with.
                                 </p>
                             </li>
                             <li>
                                 <p>
                                     You will get your own repository in the course's GitHub organization.
-                                     You will also have access
-                                    to the feedback pages for this course on Autograder.
+                                    You will also have access to the feedback pages for this course on QuickFeed.
                                 </p>
                             </li>
-
                         </ol>
 
                         <h1 id="groups">Create a new group</h1>
-
                         <ol>
-
                             <li>
                                 <p>
                                     Choose "Members" tab in the course menu on the left.
@@ -126,7 +120,7 @@ export class HelpView extends React.Component<{}, {}> {
                             </li>
                             <li>
                                 <p>
-                                The group is created after it has been approved
+                                    The group is created after it has been approved
                                     by the teaching staff. After that the group name
                                     cannot be changed. Please contact teaching staff if
                                     you wish to add or remove group members.

--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -23,14 +23,14 @@ type GitHubWebHook struct {
 	secret string
 }
 
-// NewGitHubWebHook creates a new webhook to handle POST requests from GitHub to the Autograder server.
+// NewGitHubWebHook creates a new webhook to handle POST requests from GitHub to the QuickFeed server.
 func NewGitHubWebHook(logger *zap.SugaredLogger, db database.Database, runner ci.Runner, secret string) *GitHubWebHook {
 	return &GitHubWebHook{logger: logger, db: db, runner: runner, secret: secret}
 }
 
 // Handle take POST requests from GitHub, representing Push events
 // associated with course repositories, which then triggers various
-// actions on the Autograder backend.
+// actions on the QuickFeed backend.
 func (wh GitHubWebHook) Handle(w http.ResponseWriter, r *http.Request) {
 	payload, err := github.ValidatePayload(r, []byte(wh.secret))
 	if err != nil {

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -15,7 +15,7 @@ var (
 	repoNames = fmt.Sprintf("(%s, %s, %s)",
 		pb.InfoRepo, pb.AssignmentRepo, pb.TestsRepo)
 
-	// ErrAlreadyExists indicates that one or more Autograder repositories
+	// ErrAlreadyExists indicates that one or more QuickFeed repositories
 	// already exists for the directory (or GitHub organization).
 	ErrAlreadyExists = errors.New("course repositories already exist for that organization: " + repoNames)
 	// ErrFreePlan indicates that payment plan for given organization does not allow provate


### PR DESCRIPTION
We currently retain the Autograder moniker for code, since changes
to code may impact ongoing PRs and we want to avoid such changes at
this time.

Fixes #474.

