### PR TITLE
Fix for some session-related issues

### DIFF
--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 
 	pb "github.com/autograde/quickfeed/ag"
+	"github.com/autograde/quickfeed/internal/qutil"
 )
 
 // AssignmentInfo holds metadata needed to fetch student code
@@ -27,7 +28,7 @@ func newAssignmentInfo(course *pb.Course, assignment *pb.Assignment, cloneURL, t
 		CreatorAccessToken: course.GetAccessToken(),
 		GetURL:             cloneURL,
 		TestURL:            testURL,
-		RandomSecret:       randomSecret(),
+		RandomSecret:       qutil.RandomString(),
 	}
 }
 

--- a/ci/parse_script.go
+++ b/ci/parse_script.go
@@ -7,7 +7,7 @@ import (
 	"text/template"
 
 	pb "github.com/autograde/quickfeed/ag"
-	"github.com/autograde/quickfeed/internal/qutil"
+	"github.com/autograde/quickfeed/internal/rand"
 )
 
 // AssignmentInfo holds metadata needed to fetch student code
@@ -28,7 +28,7 @@ func newAssignmentInfo(course *pb.Course, assignment *pb.Assignment, cloneURL, t
 		CreatorAccessToken: course.GetAccessToken(),
 		GetURL:             cloneURL,
 		TestURL:            testURL,
-		RandomSecret:       qutil.RandomString(),
+		RandomSecret:       rand.String(),
 	}
 }
 

--- a/ci/run_tests.go
+++ b/ci/run_tests.go
@@ -2,8 +2,6 @@ package ci
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha1"
 	"fmt"
 	"time"
 
@@ -127,14 +125,6 @@ func recordResults(logger *zap.SugaredLogger, db database.Database, rData *RunDa
 	if !rData.Rebuild {
 		updateSlipDays(logger, db, rData.Assignment, newSubmission)
 	}
-}
-
-func randomSecret() string {
-	randomness := make([]byte, 10)
-	if _, err := rand.Read(randomness); err != nil {
-		panic("couldn't generate randomness")
-	}
-	return fmt.Sprintf("%x", sha1.Sum(randomness))
 }
 
 func updateSlipDays(logger *zap.SugaredLogger, db database.Database, assignment *pb.Assignment, submission *pb.Submission) {

--- a/internal/qutil/util.go
+++ b/internal/qutil/util.go
@@ -1,0 +1,15 @@
+package qutil
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"fmt"
+)
+
+func RandomString() string {
+	randomness := make([]byte, 10)
+	if _, err := rand.Read(randomness); err != nil {
+		panic("couldn't generate randomness")
+	}
+	return fmt.Sprintf("%x", sha1.Sum(randomness))
+}

--- a/internal/rand/rand.go
+++ b/internal/rand/rand.go
@@ -1,15 +1,15 @@
-package qutil
+package rand
 
 import (
 	"crypto/rand"
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 )
 
-func RandomString() string {
+func String() string {
 	randomness := make([]byte, 10)
 	if _, err := rand.Read(randomness); err != nil {
 		panic("couldn't generate randomness")
 	}
-	return fmt.Sprintf("%x", sha1.Sum(randomness))
+	return fmt.Sprintf("%x", sha256.Sum256(randomness))
 }

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -61,7 +61,7 @@ var cookieStore = make(map[string]uint64)
 // Add adds cookie for userID, replacing userID's current cookie, if any.
 func Add(cookie string, userID uint64) {
 	for currentCookie, id := range cookieStore {
-		if id == userID && currentCookie != cookie {
+		if id != userID || (id == userID && currentCookie != cookie) {
 			delete(cookieStore, currentCookie)
 		}
 	}

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -61,7 +61,7 @@ var cookieStore = make(map[string]uint64)
 // Add adds cookie for userID, replacing userID's current cookie, if any.
 func Add(cookie string, userID uint64) {
 	for currentCookie, id := range cookieStore {
-		if id != userID || (id == userID && currentCookie != cookie) {
+		if id == userID && currentCookie != cookie {
 			delete(cookieStore, currentCookie)
 		}
 	}

--- a/web/auth/auth.go
+++ b/web/auth/auth.go
@@ -220,7 +220,6 @@ func OAuth2Callback(logger *zap.Logger, db database.Database) echo.HandlerFunc {
 				logger.Debug("failed to get logged in user from session; logout")
 				return OAuth2Logout(logger)(c)
 			}
-
 			// If type assertions fails, the recover middleware will catch the panic and log a stack trace.
 			us := i.(*UserSession)
 			// Associate user with remote identity.
@@ -298,7 +297,6 @@ func OAuth2Callback(logger *zap.Logger, db database.Database) echo.HandlerFunc {
 		if token := extractSessionCookie(w); len(token) > 0 {
 			Add(token, us.ID)
 		}
-
 		return c.Redirect(http.StatusFound, redirect)
 	}
 }
@@ -318,7 +316,7 @@ func AccessControl(logger *zap.Logger, db database.Database, scms *Scms) echo.Mi
 					logger.Error(err.Error())
 					return err
 				}
-				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+				return next(c)
 			}
 
 			i, ok := sess.Values[UserKey]

--- a/web/webserver.go
+++ b/web/webserver.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/autograde/quickfeed/internal/qutil"
 	"github.com/autograde/quickfeed/web/auth"
 	"github.com/autograde/quickfeed/web/hooks"
 	"github.com/gorilla/sessions"
@@ -35,7 +36,8 @@ func New(ags *AutograderService, public, httpAddr string) {
 		ags.logger.Fatalf("file not found %s", entryPoint)
 	}
 
-	store := newStore([]byte("secret"))
+	secret := qutil.RandomString()
+	store := newStore([]byte(secret))
 	gothic.Store = store
 	e := newServer(ags, store)
 

--- a/web/webserver.go
+++ b/web/webserver.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/autograde/quickfeed/internal/qutil"
+	"github.com/autograde/quickfeed/internal/rand"
 	"github.com/autograde/quickfeed/web/auth"
 	"github.com/autograde/quickfeed/web/hooks"
 	"github.com/gorilla/sessions"
@@ -36,7 +36,7 @@ func New(ags *AutograderService, public, httpAddr string) {
 		ags.logger.Fatalf("file not found %s", entryPoint)
 	}
 
-	secret := qutil.RandomString()
+	secret := rand.String()
 	store := newStore([]byte(secret))
 	gothic.Store = store
 	e := newServer(ags, store)


### PR DESCRIPTION
- generate random secret key for a new cookie store
- moved random string generating method to `internal` as it is useful in several places
- don't return an http error when an outdated session found