### PR TITLE
Fix save build info and add context to error returns from CreateSubmission

### DIFF
--- a/database/gormdb_submission_test.go
+++ b/database/gormdb_submission_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -202,7 +203,7 @@ func TestGormDBInsertSubmissions(t *testing.T) {
 	if err := db.CreateSubmission(&pb.Submission{
 		AssignmentID: 1,
 		UserID:       1,
-	}); err != gorm.ErrRecordNotFound {
+	}); !errors.Is(err, gorm.ErrRecordNotFound) {
 		t.Fatal(err)
 	}
 
@@ -213,7 +214,7 @@ func TestGormDBInsertSubmissions(t *testing.T) {
 	if err := db.CreateSubmission(&pb.Submission{
 		AssignmentID: assignment.ID,
 		UserID:       3,
-	}); err != gorm.ErrRecordNotFound {
+	}); !errors.Is(err, gorm.ErrRecordNotFound) {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
This is to assist with logging useful error messages in the log from outside the CreateSubmission method itself.

The goal is for this PR to also fix #527 eventually, but for now it only fixes #521. I've added TODO comments inline with some possible solutions for #527.


Fixes #521.
Fixes #527.

