### PR TITLE
Fixes button labels from Edit-Cancel to Edit-Done

### DIFF
--- a/public/src/components/teacher/CourseGroup.tsx
+++ b/public/src/components/teacher/CourseGroup.tsx
@@ -263,7 +263,7 @@ export class CourseGroup extends React.Component<ICourseGroupProps, ICourseGroup
     }
 
     private editButtonString(): string {
-        return this.state.editing ? "Cancel" : "Edit";
+        return this.state.editing ? "Done" : "Edit";
     }
 
     private generateErrorMessage(status: Status) {

--- a/public/src/pages/views/MemberView.tsx
+++ b/public/src/pages/views/MemberView.tsx
@@ -240,7 +240,7 @@ export class MemberView extends React.Component<IUserViewerProps, IUserViewerSta
     }
 
     private editButtonString(): string {
-        return this.state.editing ? "Cancel" : "Edit";
+        return this.state.editing ? "Done" : "Edit";
     }
 
     private generateUserButtons(enrollment: Enrollment): ILink[] {


### PR DESCRIPTION
When editing member and group lists we don't want to cancel, but we want to indicate that we are done editing.

Fixes #523.

