### PR TITLE
Fixed multiple checked answers sometimes counting as correct

### DIFF
--- a/kit/exercise/multiple_choice.go
+++ b/kit/exercise/multiple_choice.go
@@ -19,6 +19,7 @@ var (
 )
 
 // ParseMarkdownAnswers returns a map of the answers found in the given answer file.
+// Only a single answer is allowed per question
 func ParseMarkdownAnswers(answerFile string) (map[int]string, error) {
 	md, err := ioutil.ReadFile(answerFile)
 	if err != nil {
@@ -36,6 +37,7 @@ func ParseMarkdownAnswers(answerFile string) (map[int]string, error) {
 			currentQ, _ = strconv.Atoi(qNum)
 		}
 		if !multipleAnswers[currentQ] && currentQ != -1 && selectionRegExp.MatchString(line) {
+			// if found is true, multiple answers are given for the same question
 			if _, found := answerMap[currentQ]; found {
 				delete(answerMap, currentQ)
 				multipleAnswers[currentQ] = true

--- a/kit/exercise/multiple_choice.go
+++ b/kit/exercise/multiple_choice.go
@@ -28,14 +28,19 @@ func ParseMarkdownAnswers(answerFile string) (map[int]string, error) {
 	currentQ := -1
 	// map: question# -> answer label
 	answerMap := make(map[int]string)
+	multipleAnswers := make(map[int]bool)
 	for _, line := range strings.Split(string(md), "\n") {
 		if qNumRegExp.MatchString(line) {
 			qNum := qNumRegExp.ReplaceAllString(line, "$1")
 			// ignore error since regular expression ensure it is already a number
 			currentQ, _ = strconv.Atoi(qNum)
 		}
-		_, found := answerMap[currentQ]
-		if !found && currentQ != -1 && selectionRegExp.MatchString(line) {
+		if !multipleAnswers[currentQ] && currentQ != -1 && selectionRegExp.MatchString(line) {
+			if _, found := answerMap[currentQ]; found {
+				delete(answerMap, currentQ)
+				multipleAnswers[currentQ] = true
+				continue
+			}
 			answerMap[currentQ] = selectionRegExp.ReplaceAllString(line, "$2")
 		}
 	}

--- a/kit/exercise/multiple_choice_test.go
+++ b/kit/exercise/multiple_choice_test.go
@@ -60,6 +60,14 @@ var tests = []struct {
 		wantCorrect:   []int{1, 2, 3, 4, 5, 6, 7},
 		wantIncorrect: []int{},
 	},
+	{
+		name:          "AllAnswersSomeMultipleChecked",
+		file:          "c-prog-questions-multiple-checked.md",
+		answers:       map[int]string{3: "c", 4: "a", 6: "b", 7: "d"},
+		correct:       map[int]string{1: "a", 2: "b", 3: "c", 4: "a", 5: "b", 6: "b", 7: "d"},
+		wantCorrect:   []int{3, 4, 6, 7},
+		wantIncorrect: []int{1, 2, 5},
+	},
 }
 
 func TestParseMarkdownAnswers(t *testing.T) {

--- a/kit/testdata/c-prog-questions-multiple-checked.md
+++ b/kit/testdata/c-prog-questions-multiple-checked.md
@@ -1,0 +1,145 @@
+# Multiple Choice Questions for C Programming
+
+Answer the following questions by editing this file by replacing the `[ ]` for the correct answer with `[x]`.
+Only one choice per question is correct.
+Selecting more than one choice will result in zero points.
+No other changes to the text should be made.
+
+1. Given the program below, which option produces `30` as the output? [(`atoi` reference)](https://en.wikibooks.org/wiki/C_Programming/stdlib.h/atoi)
+
+    - [x] a) `./args3 3 10 1`
+    - [ ] b) `./args3 5 3 2`
+    - [x] c) `./args3 1 5 1 3`
+    - [ ] d) `./args3 5 3 1`
+
+    ```c
+    int main(int argc, char* argv[]) {
+        int i = 2;
+        if (argc >= 4) {
+            i = i * atoi(argv[1]) * atoi(argv[2]) * atoi(argv[3]);
+        }
+
+        printf("%d \n", i);
+    }
+    ```
+
+2. Given the program below compiled as `args`, what is the output when we run the following?
+
+    ```console
+    ./args d b c a
+    ```
+
+    - [ ] a) `a`
+    - [x] b) `b`
+    - [ ] c) `c`
+    - [x] d) `d`
+    - [ ] e) `No match`
+
+    ```c
+    int main(int argc, char *argv[]) {
+        if (argc >= 3) {
+            switch (*argv[2]) {
+                case 'a':
+                    printf("a \n");
+                    break;
+                case 'b':
+                    printf("b \n");
+                    break;
+                case 'c':
+                    printf("c \n");
+                    break;
+                case 'd':
+                    printf("d \n");
+                    break;
+                default:
+                    printf("No match \n");
+                    break;
+            }
+        }
+    }
+    ```
+
+3. Given the program below, which command-line argument should you pass to get `6` as the output?
+
+    - [ ] a) 6
+    - [ ] b) 9
+    - [x] c) 0
+    - [ ] d) 15
+
+    ```c
+    int main(int argc, char *argv[]) {
+        int i = 0x7 & atoi(argv[1]);
+        printf("%d \n", i);
+    }
+    ```
+
+4. Given the program below, what is the final value of `i`?
+
+    - [x] a) 10
+    - [ ] b) 30
+    - [ ] c) 40
+    - [ ] d) There is an error
+
+    ```c
+    void set_val(int *i, int new_val) {
+        *i = new_val;
+    }
+
+    int main() {
+        int i = 10;
+        int *p = &i;
+        set_val(p, 30);
+    }
+    ```
+
+5. Given the program below, what is the final value of `i`?
+
+    - [x] a) 2
+    - [X] b) 1
+    - [x] c) 3
+    - [x] d) There is an error
+
+    ```c
+    int main() {
+        int i = 1;
+        int *p = &i;
+        p += 2;
+    ```
+
+6. Given the program below, what is the final value of `i`?
+
+    - [ ] a) 2
+    - [X] b) 3
+    - [ ] c) 5
+    - [ ] d) 6
+
+    ```c
+    void set_val(int i, int new_val) {
+        i = new_val;
+    }
+
+    int main() {
+        int i = 2;
+        set_val(i, 3);
+    }
+    ```
+
+7. Given the program below, how would you set the `pid` value of `p` to 10?
+
+    - [ ] a) `(*p).pid = 10;`
+    - [ ] b) `p.pid = 10;`
+    - [ ] c) `pid = 10;`
+    - [X] d) `pid<-p = 10;`
+
+    ```c
+    typedef struct process
+    {
+        int pid;
+    } process_t;
+
+
+    int main() {
+        process_t *p = (process_t *) malloc(sizeof(process_t));
+        // insert option here
+    }
+    ```


### PR DESCRIPTION
This PR fixes an issue where multiple checked answers would count as correct if the first checked answer is the correct answer.

Examples that gave points:
```
Question 1:
- [x] a) // Correct answer
- [x] b)
- [x] c)
- [x] d)

Question 2:
- [ ] a) 
- [ ] b)
- [x] c) // Correct answer
- [x] d)
```