### PR TITLE
Fixes rounding error in Results.Sum()

### DIFF
--- a/kit/score/results.go
+++ b/kit/score/results.go
@@ -1,6 +1,7 @@
 package score
 
 import (
+	"math"
 	"strings"
 	"time"
 )
@@ -95,20 +96,20 @@ func (r *Results) Validate(secret string) error {
 // The total is a grade in the range 0-100.
 // This method must only be called after Validate has returned nil.
 func (r *Results) Sum() uint32 {
-	totalWeight := float32(0)
-	var max, score, weight []float32
+	totalWeight := float64(0)
+	var max, score, weight []float64
 	for _, ts := range r.GetScores() {
-		totalWeight += float32(ts.Weight)
-		weight = append(weight, float32(ts.Weight))
-		score = append(score, float32(ts.Score))
-		max = append(max, float32(ts.MaxScore))
+		totalWeight += float64(ts.Weight)
+		weight = append(weight, float64(ts.Weight))
+		score = append(score, float64(ts.Score))
+		max = append(max, float64(ts.MaxScore))
 	}
-	total := float32(0)
+	total := float64(0)
 	for i := 0; i < len(score); i++ {
 		if score[i] > max[i] {
 			score[i] = max[i]
 		}
-		total += ((score[i] / max[i]) * (weight[i] / totalWeight))
+		total += (score[i] / max[i]) * (weight[i] / totalWeight)
 	}
-	return uint32(total * 100)
+	return uint32(math.Round(total * 100))
 }

--- a/kit/score/results_test.go
+++ b/kit/score/results_test.go
@@ -142,7 +142,53 @@ func TestScoresSum(t *testing.T) {
 	got := results.Sum()
 	const want = 100
 	if got != want {
-		t.Errorf("Sum() = '%d', want '%d'", got, want)
+		t.Errorf("Sum() = %d, want %d", got, want)
+	}
+}
+
+// RegExp to extract from JSON output: \{\W+"Secret": "hidden",\W+"(\w+)"(:.*)\W+"(\w+)"(:.*)\W+"(\w+)"(:.*)\W+"(\w+)"(:\W+\d+)
+
+var score100 = []*score.Score{
+	{TestName: "TestVetCheckAG", Score: 1, MaxScore: 1, Weight: 5},
+	{TestName: "TestFormattingAG", Score: 1, MaxScore: 1, Weight: 5},
+	{TestName: "TestTODOItemsAG", Score: 1, MaxScore: 1, Weight: 5},
+	{TestName: "TestLintAG", Score: 1, MaxScore: 1, Weight: 5},
+	{TestName: "TestAverageMetrics/fifo/book_schedule1", Score: 4, MaxScore: 4, Weight: 4},
+	{TestName: "TestAverageMetrics/fifo/book_schedule2", Score: 4, MaxScore: 4, Weight: 4},
+	{TestName: "TestAverageMetrics/fifo/book_schedule3", Score: 4, MaxScore: 4, Weight: 4},
+	{TestName: "TestAverageMetrics/rr/book_schedule1/q=1ms", Score: 4, MaxScore: 4, Weight: 4},
+	{TestName: "TestRoundRobin", Score: 169, MaxScore: 169, Weight: 30},
+	{TestName: "TestSingleJobMetrics/rr/book_schedule3/q=1ms", Score: 2, MaxScore: 2, Weight: 2},
+	{TestName: "TestAverageMetrics/rr/book_schedule2/q=1ms", Score: 4, MaxScore: 4, Weight: 4},
+	{TestName: "TestAverageMetrics/rr/book_schedule3/q=1ms", Score: 4, MaxScore: 4, Weight: 4},
+	{TestName: "TestShortestJobFirst", Score: 163, MaxScore: 163, Weight: 20},
+	{TestName: "TestStride", Score: 248, MaxScore: 248, Weight: 30},
+	{TestName: "TestMinPass", Score: 5, MaxScore: 5, Weight: 5},
+	{TestName: "TestStrideNewJob", Score: 2, MaxScore: 2, Weight: 2},
+	{TestName: "TestSingleJobMetrics/fifo/book_schedule1", Score: 2, MaxScore: 2, Weight: 2},
+	{TestName: "TestSingleJobMetrics/fifo/book_schedule2", Score: 2, MaxScore: 2, Weight: 2},
+	{TestName: "TestSingleJobMetrics/fifo/book_schedule3", Score: 2, MaxScore: 2, Weight: 2},
+	{TestName: "TestSingleJobMetrics/rr/book_schedule1/q=1ms", Score: 2, MaxScore: 2, Weight: 2},
+	{TestName: "TestSingleJobMetrics/rr/book_schedule2/q=1ms", Score: 2, MaxScore: 2, Weight: 2},
+}
+
+func TestScore100(t *testing.T) {
+	const want = 100
+	scoreTable := score.NewResults()
+	for _, sc := range score100 {
+		scoreTable.AddScore(sc)
+		if sc.Score != sc.MaxScore {
+			// sanity check; all scores must be max
+			t.Errorf("%s Score=%d, expected %d", sc.TestName, sc.Score, sc.MaxScore)
+		}
+	}
+	results := &score.Results{Scores: scoreTable.ToScoreSlice()}
+	if err := results.Validate(""); err != nil {
+		t.Error(err)
+	}
+	got := results.Sum()
+	if got != want {
+		t.Errorf("Sum() = %d, want %d", got, want)
 	}
 }
 

--- a/kit/score/totalscore_test.go
+++ b/kit/score/totalscore_test.go
@@ -27,7 +27,7 @@ var scoreGrades = []struct {
 			{TestName: "B", Score: 05, MaxScore: 05, Weight: 1},
 			{TestName: "C", Score: 20, MaxScore: 40, Weight: 1},
 		},
-		out:       66,
+		out:       67,
 		wantGrade: "C",
 	},
 	{


### PR DESCRIPTION
This fixes a rounding error discovered recently that would result in a score of 99 instead of 100, when all scores were equal to the max score.

Fixes #542.

