### PR TITLE
Fix test ordering issue

### DIFF
--- a/kit/score/main_test.go
+++ b/kit/score/main_test.go
@@ -11,7 +11,11 @@ import (
 var scores = score.NewRegistry()
 
 func TestMain(m *testing.M) {
+	fmt.Println("Registration order:")
 	scores.PrintTestInfo()
+	// print also in sorted order for the benefit of TestPrintTestInfoOrder
+	fmt.Println("Sorted order:")
+	scores.PrintTestInfo(true)
 	exitCode := m.Run()
 	if err := scores.Validate(); err != nil {
 		fmt.Println(err)

--- a/kit/score/registry_test.go
+++ b/kit/score/registry_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/autograde/quickfeed/kit/score/testdata/a"
+	"github.com/autograde/quickfeed/kit/sh"
+	"github.com/google/go-cmp/cmp"
 )
 
 func fib() {}
@@ -51,5 +53,30 @@ func TestTestNamePanic(t *testing.T) {
 				t.Errorf("testName('%s')='%s', expected to fail", test.inName, tName)
 			}
 		})
+	}
+}
+
+func TestPrintTestInfoOrder(t *testing.T) {
+	got, err := sh.Output("go test -run TestTestNamePanic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedPrefixOrder := `Registration order:
+{"TestName":"TestPanicTriangularBefore","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicTriangularPanic","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicTriangularAfter","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicHandler","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicTriangularPanicWithMsg","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicHandlerWithMsg","MaxScore":8,"Weight":5}
+Sorted order:
+{"TestName":"TestPanicHandler","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicHandlerWithMsg","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicTriangularAfter","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicTriangularBefore","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicTriangularPanic","MaxScore":8,"Weight":5}
+{"TestName":"TestPanicTriangularPanicWithMsg","MaxScore":8,"Weight":5}
+`
+	if diff := cmp.Diff(expectedPrefixOrder, got[:len(expectedPrefixOrder)]); diff != "" {
+		t.Errorf("PrintTestInfo(): (-want +got):\n%s", diff)
 	}
 }

--- a/kit/score/results.go
+++ b/kit/score/results.go
@@ -82,7 +82,7 @@ func (r *results) AddScore(sc *Score) {
 			sc.Score = -1
 		}
 	} else {
-		// New test: record in TestNames
+		// New test: record in r.testNames
 		r.testNames = append(r.testNames, testName)
 	}
 


### PR DESCRIPTION
PrintTestInfo() will print tests in the order they appear in the
init() functions. There is no ordering across different init()
functions, so if multiple init() functions generate an undesirable
ordering of tests, those init() functions can be combined into one.

PrintTestInfo(sorted=true) will print all tests in sorted order.

Fixes #534.

